### PR TITLE
Update DDSWithoutD3DX (D3D10)

### DIFF
--- a/C++/Direct3D10/DDSWithoutD3DX/DDS.h
+++ b/C++/Direct3D10/DDSWithoutD3DX/DDS.h
@@ -1,76 +1,206 @@
 //--------------------------------------------------------------------------------------
-// dds.h
+// DDS.h
 //
-// This header defines constants and structures that are useful when parsing 
+// This header defines constants and structures that are useful when parsing
 // DDS files.  DDS files were originally designed to use several structures
 // and constants that are native to DirectDraw and are defined in ddraw.h,
-// such as DDSURFACEDESC2 and DDSCAPS2.  This file defines similar 
-// (compatible) constants and structures so that one can use DDS files 
+// such as DDSURFACEDESC2 and DDSCAPS2.  This file defines similar
+// (compatible) constants and structures so that one can use DDS files
 // without needing to include ddraw.h.
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// http://go.microsoft.com/fwlink/?LinkId=248926
+// http://go.microsoft.com/fwlink/?LinkId=248929
+// http://go.microsoft.com/fwlink/?LinkID=615561
 //--------------------------------------------------------------------------------------
 
-#ifndef _DDS_H_
-#define _DDS_H_
+#pragma once
 
-#include <dxgiformat.h>
+#include <cstdint>
+
+namespace DirectX
+{
 
 #pragma pack(push,1)
 
-#define DDS_MAGIC 0x20534444 // "DDS "
+    constexpr uint32_t DDS_MAGIC = 0x20534444; // "DDS "
 
-struct DDS_PIXELFORMAT
-{
-    DWORD dwSize;
-    DWORD dwFlags;
-    DWORD dwFourCC;
-    DWORD dwRGBBitCount;
-    DWORD dwRBitMask;
-    DWORD dwGBitMask;
-    DWORD dwBBitMask;
-    DWORD dwABitMask;
-};
+    struct DDS_PIXELFORMAT
+    {
+        uint32_t    size;
+        uint32_t    flags;
+        uint32_t    fourCC;
+        uint32_t    RGBBitCount;
+        uint32_t    RBitMask;
+        uint32_t    GBitMask;
+        uint32_t    BBitMask;
+        uint32_t    ABitMask;
+    };
 
-#define DDS_FOURCC      0x00000004  // DDPF_FOURCC
-#define DDS_RGB         0x00000040  // DDPF_RGB
-#define DDS_RGBA        0x00000041  // DDPF_RGB | DDPF_ALPHAPIXELS
-#define DDS_LUMINANCE   0x00020000  // DDPF_LUMINANCE
-#define DDS_ALPHA       0x00000002  // DDPF_ALPHA
+#define DDS_FOURCC        0x00000004  // DDPF_FOURCC
+#define DDS_RGB           0x00000040  // DDPF_RGB
+#define DDS_RGBA          0x00000041  // DDPF_RGB | DDPF_ALPHAPIXELS
+#define DDS_LUMINANCE     0x00020000  // DDPF_LUMINANCE
+#define DDS_LUMINANCEA    0x00020001  // DDPF_LUMINANCE | DDPF_ALPHAPIXELS
+#define DDS_ALPHAPIXELS   0x00000001  // DDPF_ALPHAPIXELS
+#define DDS_ALPHA         0x00000002  // DDPF_ALPHA
+#define DDS_PAL8          0x00000020  // DDPF_PALETTEINDEXED8
+#define DDS_PAL8A         0x00000021  // DDPF_PALETTEINDEXED8 | DDPF_ALPHAPIXELS
+#define DDS_BUMPLUMINANCE 0x00040000  // DDPF_BUMPLUMINANCE
+#define DDS_BUMPDUDV      0x00080000  // DDPF_BUMPDUDV
+#define DDS_BUMPDUDVA     0x00080001  // DDPF_BUMPDUDV | DDPF_ALPHAPIXELS
 
-const DDS_PIXELFORMAT DDSPF_DXT1 =
+#ifndef MAKEFOURCC
+#define MAKEFOURCC(ch0, ch1, ch2, ch3) \
+                (static_cast<uint32_t>(static_cast<uint8_t>(ch0)) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch1)) << 8) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch2)) << 16) \
+                | (static_cast<uint32_t>(static_cast<uint8_t>(ch3)) << 24))
+#endif /* MAKEFOURCC */
+
+#ifndef DDSGLOBALCONST
+#if defined(__GNUC__) && !defined(__MINGW32__)
+#define DDSGLOBALCONST extern const __attribute__((weak))
+#else
+#define DDSGLOBALCONST extern const __declspec(selectany)
+#endif
+#endif /* DDSGLOBALCONST */
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_DXT1 =
     { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','1'), 0, 0, 0, 0, 0 };
 
-const DDS_PIXELFORMAT DDSPF_DXT2 =
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_DXT2 =
     { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','2'), 0, 0, 0, 0, 0 };
 
-const DDS_PIXELFORMAT DDSPF_DXT3 =
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_DXT3 =
     { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','3'), 0, 0, 0, 0, 0 };
 
-const DDS_PIXELFORMAT DDSPF_DXT4 =
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_DXT4 =
     { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','4'), 0, 0, 0, 0, 0 };
 
-const DDS_PIXELFORMAT DDSPF_DXT5 =
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_DXT5 =
     { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','T','5'), 0, 0, 0, 0, 0 };
 
-const DDS_PIXELFORMAT DDSPF_A8R8G8B8 =
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_BC4_UNORM =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B','C','4','U'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_BC4_SNORM =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B','C','4','S'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_BC5_UNORM =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B','C','5','U'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_BC5_SNORM =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('B','C','5','S'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_R8G8_B8G8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('R','G','B','G'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_G8R8_G8B8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('G','R','G','B'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_YUY2 =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('Y','U','Y','2'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_UYVY =
+    { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('U','Y','V','Y'), 0, 0, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A8R8G8B8 =
     { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 32, 0x00ff0000, 0x0000ff00, 0x000000ff, 0xff000000 };
 
-const DDS_PIXELFORMAT DDSPF_A1R5G5B5 =
-    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 16, 0x00007c00, 0x000003e0, 0x0000001f, 0x00008000 };
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_X8R8G8B8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB,  0, 32, 0x00ff0000, 0x0000ff00, 0x000000ff, 0 };
 
-const DDS_PIXELFORMAT DDSPF_A4R4G4B4 =
-    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 16, 0x00000f00, 0x000000f0, 0x0000000f, 0x0000f000 };
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A8B8G8R8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000 };
 
-const DDS_PIXELFORMAT DDSPF_R8G8B8 =
-    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 24, 0x00ff0000, 0x0000ff00, 0x000000ff, 0x00000000 };
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_X8B8G8R8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB,  0, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0 };
 
-const DDS_PIXELFORMAT DDSPF_R5G6B5 =
-    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 16, 0x0000f800, 0x000007e0, 0x0000001f, 0x00000000 };
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_G16R16 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB,  0, 32, 0x0000ffff, 0xffff0000, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_R5G6B5 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 16, 0xf800, 0x07e0, 0x001f, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A1R5G5B5 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 16, 0x7c00, 0x03e0, 0x001f, 0x8000 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_X1R5G5B5 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 16, 0x7c00, 0x03e0, 0x001f, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A4R4G4B4 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 16, 0x0f00, 0x00f0, 0x000f, 0xf000 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_X4R4G4B4 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 16, 0x0f00, 0x00f0, 0x000f, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_R8G8B8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 24, 0xff0000, 0x00ff00, 0x0000ff, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A8R3G3B2 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 16, 0x00e0, 0x001c, 0x0003, 0xff00 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_R3G3B2 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 8, 0xe0, 0x1c, 0x03, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A4L4 =
+    { sizeof(DDS_PIXELFORMAT), DDS_LUMINANCEA, 0, 8, 0x0f, 0, 0, 0xf0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_L8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_LUMINANCE, 0, 8, 0xff, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_L16 =
+    { sizeof(DDS_PIXELFORMAT), DDS_LUMINANCE, 0, 16, 0xffff, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A8L8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_LUMINANCEA, 0, 16, 0x00ff, 0, 0, 0xff00 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A8L8_ALT =
+    { sizeof(DDS_PIXELFORMAT), DDS_LUMINANCEA, 0, 8, 0x00ff, 0, 0, 0xff00 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_L8_NVTT1 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 8, 0xff, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_L16_NVTT1 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGB, 0, 16, 0xffff, 0, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A8L8_NVTT1 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 16, 0x00ff, 0, 0, 0xff00 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_ALPHA, 0, 8, 0, 0, 0, 0xff };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_V8U8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_BUMPDUDV, 0, 16, 0x00ff, 0xff00, 0, 0 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_Q8W8V8U8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_BUMPDUDV, 0, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000 };
+
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_V16U16 =
+    { sizeof(DDS_PIXELFORMAT), DDS_BUMPDUDV, 0, 32, 0x0000ffff, 0xffff0000, 0, 0 };
+
+// D3DFMT_A2R10G10B10/D3DFMT_A2B10G10R10 should be written using DX10 extension to avoid D3DX 10:10:10:2 reversal issue
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A2R10G10B10 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 32, 0x000003ff, 0x000ffc00, 0x3ff00000, 0xc0000000 };
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A2B10G10R10 =
+    { sizeof(DDS_PIXELFORMAT), DDS_RGBA, 0, 32, 0x3ff00000, 0x000ffc00, 0x000003ff, 0xc0000000 };
+
+// The following legacy Direct3D 9 formats use 'mixed' signed & unsigned channels so requires special handling
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_A2W10V10U10 =
+    { sizeof(DDS_PIXELFORMAT), DDS_BUMPDUDVA, 0, 32, 0x3ff00000, 0x000ffc00, 0x000003ff, 0xc0000000 };
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_L6V5U5 =
+    { sizeof(DDS_PIXELFORMAT), DDS_BUMPLUMINANCE, 0, 16, 0x001f, 0x03e0, 0xfc00, 0 };
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_X8L8V8U8 =
+    { sizeof(DDS_PIXELFORMAT), DDS_BUMPLUMINANCE, 0, 32, 0x000000ff, 0x0000ff00, 0x00ff0000, 0 };
 
 // This indicates the DDS_HEADER_DXT10 extension is present (the format is in dxgiFormat)
-const DDS_PIXELFORMAT DDSPF_DX10 =
+    DDSGLOBALCONST DDS_PIXELFORMAT DDSPF_DX10 =
     { sizeof(DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('D','X','1','0'), 0, 0, 0, 0, 0 };
 
-#define DDS_HEADER_FLAGS_TEXTURE        0x00001007  // DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT 
+#define DDS_HEADER_FLAGS_TEXTURE        0x00001007  // DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT
 #define DDS_HEADER_FLAGS_MIPMAP         0x00020000  // DDSD_MIPMAPCOUNT
 #define DDS_HEADER_FLAGS_VOLUME         0x00800000  // DDSD_DEPTH
 #define DDS_HEADER_FLAGS_PITCH          0x00000008  // DDSD_PITCH
@@ -99,46 +229,102 @@ const DDS_PIXELFORMAT DDSPF_DX10 =
 #define DDS_FLAGS_VOLUME 0x00200000 // DDSCAPS2_VOLUME
 
 // Subset here matches D3D10_RESOURCE_DIMENSION and D3D11_RESOURCE_DIMENSION
-typedef enum DDS_RESOURCE_DIMENSION
-{
-    DDS_DIMENSION_TEXTURE1D	= 2,
-    DDS_DIMENSION_TEXTURE2D	= 3,
-    DDS_DIMENSION_TEXTURE3D	= 4,
-} DDS_RESOURCE_DIMENSION;
+    enum DDS_RESOURCE_DIMENSION : uint32_t
+    {
+        DDS_DIMENSION_TEXTURE1D = 2,
+        DDS_DIMENSION_TEXTURE2D = 3,
+        DDS_DIMENSION_TEXTURE3D = 4,
+    };
 
-// Subset here matches D3D10_RESOURCE_MISC_FLAG and D3D11_RESOURCE_MISC_FLAG
-typedef enum DDS_RESOURCE_MISC_FLAG
-{
-   DDS_RESOURCE_MISC_TEXTURECUBE = 0x4L,
-} DDS_RESOURCE_MISC_FLAG;
+    // Subset here matches D3D10_RESOURCE_MISC_FLAG and D3D11_RESOURCE_MISC_FLAG
+    enum DDS_RESOURCE_MISC_FLAG : uint32_t
+    {
+        DDS_RESOURCE_MISC_TEXTURECUBE = 0x4L,
+    };
 
-typedef struct
-{
-    DWORD dwSize;
-    DWORD dwFlags;
-    DWORD dwHeight;
-    DWORD dwWidth;
-    DWORD dwPitchOrLinearSize;
-    DWORD dwDepth; // only if DDS_HEADER_FLAGS_VOLUME is set in dwFlags
-    DWORD dwMipMapCount;
-    DWORD dwReserved1[11];
-    DDS_PIXELFORMAT ddspf;
-    DWORD dwCaps;
-    DWORD dwCaps2;
-    DWORD dwCaps3;
-    DWORD dwCaps4;
-    DWORD dwReserved2;
-} DDS_HEADER;
+    enum DDS_MISC_FLAGS2 : uint32_t
+    {
+        DDS_MISC_FLAGS2_ALPHA_MODE_MASK = 0x7L,
+    };
 
-typedef struct
-{
-    DXGI_FORMAT dxgiFormat;
-    UINT resourceDimension;
-    DWORD miscFlag; // see DDS_RESOURCE_MISC_FLAG
-    UINT arraySize;
-    UINT reserved;
-} DDS_HEADER_DXT10;
+#ifndef DDS_ALPHA_MODE_DEFINED
+#define DDS_ALPHA_MODE_DEFINED
+    enum DDS_ALPHA_MODE : uint32_t
+    {
+        DDS_ALPHA_MODE_UNKNOWN = 0,
+        DDS_ALPHA_MODE_STRAIGHT = 1,
+        DDS_ALPHA_MODE_PREMULTIPLIED = 2,
+        DDS_ALPHA_MODE_OPAQUE = 3,
+        DDS_ALPHA_MODE_CUSTOM = 4,
+    };
+#endif
+
+    struct DDS_HEADER
+    {
+        uint32_t        size;
+        uint32_t        flags;
+        uint32_t        height;
+        uint32_t        width;
+        uint32_t        pitchOrLinearSize;
+        uint32_t        depth; // only if DDS_HEADER_FLAGS_VOLUME is set in flags
+        uint32_t        mipMapCount;
+        uint32_t        reserved1[11];
+        DDS_PIXELFORMAT ddspf;
+        uint32_t        caps;
+        uint32_t        caps2;
+        uint32_t        caps3;
+        uint32_t        caps4;
+        uint32_t        reserved2;
+    };
+
+    struct DDS_HEADER_DXT10
+    {
+        DXGI_FORMAT     dxgiFormat;
+        uint32_t        resourceDimension;
+        uint32_t        miscFlag; // see D3D11_RESOURCE_MISC_FLAG
+        uint32_t        arraySize;
+        uint32_t        miscFlags2; // see DDS_MISC_FLAGS2
+    };
 
 #pragma pack(pop)
 
-#endif // _DDS_H
+    static_assert(sizeof(DDS_PIXELFORMAT) == 32, "DDS pixel format size mismatch");
+    static_assert(sizeof(DDS_HEADER) == 124, "DDS Header size mismatch");
+    static_assert(sizeof(DDS_HEADER_DXT10) == 20, "DDS DX10 Extended Header size mismatch");
+
+    constexpr size_t DDS_MIN_HEADER_SIZE = sizeof(uint32_t) + sizeof(DDS_HEADER);
+    constexpr size_t DDS_DX10_HEADER_SIZE = sizeof(uint32_t) + sizeof(DDS_HEADER) + sizeof(DDS_HEADER_DXT10);
+    static_assert(DDS_DX10_HEADER_SIZE > DDS_MIN_HEADER_SIZE, "DDS DX10 Header should be larger than standard header");
+
+} // namespace
+
+namespace Xbox
+{
+    DDSGLOBALCONST DirectX::DDS_PIXELFORMAT DDSPF_XBOX =
+    { sizeof(DirectX::DDS_PIXELFORMAT), DDS_FOURCC, MAKEFOURCC('X','B','O','X'), 0, 0, 0, 0, 0 };
+
+#pragma pack(push,1)
+
+    struct DDS_HEADER_XBOX
+        // Must match structure in XboxDDSTextureLoader module
+    {
+        DXGI_FORMAT dxgiFormat;
+        uint32_t    resourceDimension;
+        uint32_t    miscFlag; // see DDS_RESOURCE_MISC_FLAG
+        uint32_t    arraySize;
+        uint32_t    miscFlags2; // see DDS_MISC_FLAGS2
+        uint32_t    tileMode; // see XG_TILE_MODE / XG_SWIZZLE_MODE
+        uint32_t    baseAlignment;
+        uint32_t    dataSize;
+        uint32_t    xdkVer; // matching _XDK_VER / _GXDK_VER
+    };
+
+#pragma pack(pop)
+
+    static_assert(sizeof(DDS_HEADER_XBOX) == 36, "DDS XBOX Header size mismatch");
+    static_assert(sizeof(DDS_HEADER_XBOX) > sizeof(DirectX::DDS_HEADER_DXT10), "DDS XBOX Header should be larger than DX10 header");
+
+    constexpr size_t DDS_XBOX_HEADER_SIZE = sizeof(uint32_t) + sizeof(DirectX::DDS_HEADER) + sizeof(DDS_HEADER_XBOX);
+
+    constexpr uint32_t XBOX_TILEMODE_SCARLETT = 0x1000000;
+} // namespace

--- a/C++/Direct3D10/DDSWithoutD3DX/DDSTextureLoader.cpp
+++ b/C++/Direct3D10/DDSWithoutD3DX/DDSTextureLoader.cpp
@@ -10,6 +10,10 @@
 #include "DDSTextureLoader.h"
 #include "DDS.h"
 
+#include <new>
+
+using namespace DirectX;
+
 //--------------------------------------------------------------------------------------
 static HRESULT LoadTextureDataFromFile( __in_z const WCHAR* szFileName, BYTE** ppHeapData,
                                         DDS_HEADER** ppHeader,
@@ -22,7 +26,7 @@ static HRESULT LoadTextureDataFromFile( __in_z const WCHAR* szFileName, BYTE** p
         return HRESULT_FROM_WIN32( GetLastError() );
 
     // Get the file size
-    LARGE_INTEGER FileSize = {0};
+    LARGE_INTEGER FileSize = {};
     GetFileSizeEx( hFile, &FileSize );
 
     // File is too big for 32-bit allocation, so reject read
@@ -33,14 +37,14 @@ static HRESULT LoadTextureDataFromFile( __in_z const WCHAR* szFileName, BYTE** p
     }
 
     // Need at least enough data to fill the header and magic number to be a valid DDS
-    if( FileSize.LowPart < (sizeof(DDS_HEADER)+sizeof(DWORD)) )
+    if ( FileSize.LowPart < DDS_MIN_HEADER_SIZE )
     {
         CloseHandle( hFile );
         return E_FAIL;
     }
 
     // create enough space for the file data
-    *ppHeapData = new BYTE[ FileSize.LowPart ];
+    *ppHeapData = new (std::nothrow) BYTE[FileSize.LowPart];
     if( !( *ppHeapData ) )
     {
         CloseHandle( hFile );
@@ -75,8 +79,8 @@ static HRESULT LoadTextureDataFromFile( __in_z const WCHAR* szFileName, BYTE** p
     DDS_HEADER* pHeader = reinterpret_cast<DDS_HEADER*>( *ppHeapData + sizeof( DWORD ) );
 
     // Verify header to validate DDS file
-    if( pHeader->dwSize != sizeof(DDS_HEADER)
-        || pHeader->ddspf.dwSize != sizeof(DDS_PIXELFORMAT) )
+    if( pHeader->size != sizeof(DDS_HEADER)
+        || pHeader->ddspf.size != sizeof(DDS_PIXELFORMAT) )
     {
         CloseHandle( hFile );
         SAFE_DELETE_ARRAY( *ppHeapData );
@@ -85,11 +89,11 @@ static HRESULT LoadTextureDataFromFile( __in_z const WCHAR* szFileName, BYTE** p
 
     // Check for DX10 extension
     bool bDXT10Header = false;
-    if ( (pHeader->ddspf.dwFlags & DDS_FOURCC)
-        && (MAKEFOURCC( 'D', 'X', '1', '0' ) == pHeader->ddspf.dwFourCC) )
+    if ( (pHeader->ddspf.flags & DDS_FOURCC)
+        && (MAKEFOURCC( 'D', 'X', '1', '0' ) == pHeader->ddspf.fourCC) )
     {
         // Must be long enough for both headers and magic value
-        if( FileSize.LowPart < (sizeof(DDS_HEADER)+sizeof(DWORD)+sizeof(DDS_HEADER_DXT10)) )
+        if (FileSize.LowPart < DDS_DX10_HEADER_SIZE)
         {
             CloseHandle( hFile );
             SAFE_DELETE_ARRAY( *ppHeapData );
@@ -101,7 +105,7 @@ static HRESULT LoadTextureDataFromFile( __in_z const WCHAR* szFileName, BYTE** p
 
     // setup the pointers in the process request
     *ppHeader = pHeader;
-    INT offset = sizeof( DWORD ) + sizeof( DDS_HEADER )
+    INT offset = DDS_MIN_HEADER_SIZE
                  + (bDXT10Header ? sizeof( DDS_HEADER_DXT10 ) : 0);
     *ppBitData = *ppHeapData + offset;
     *pBitSize = FileSize.LowPart - offset;
@@ -359,14 +363,14 @@ static void GetSurfaceInfo( UINT width, UINT height, D3DFORMAT fmt, UINT* pNumBy
 
     // From the DXSDK docs:
     //
-    //     When computing DXTn compressed sizes for non-square textures, the 
+    //     When computing DXTn compressed sizes for non-square textures, the
     //     following formula should be used at each mipmap level:
     //
-    //         max(1, width ÷ 4) x max(1, height ÷ 4) x 8(DXT1) or 16(DXT2-5)
+    //         max(1, width / 4) x max(1, height / 4) x 8(DXT1) or 16(DXT2-5)
     //
-    //     The pitch for DXTn formats is different from what was returned in 
-    //     Microsoft DirectX 7.0. It now refers the pitch of a row of blocks. 
-    //     For example, if you have a width of 16, then you will have a pitch 
+    //     The pitch for DXTn formats is different from what was returned in
+    //     Microsoft DirectX 7.0. It now refers the pitch of a row of blocks.
+    //     For example, if you have a width of 16, then you will have a pitch
     //     of four blocks (4*8 for DXT1, 4*16 for DXT2-5.)"
 
     switch( fmt )
@@ -497,14 +501,14 @@ static void GetSurfaceInfo( UINT width, UINT height, DXGI_FORMAT fmt, UINT* pNum
 
 
 //--------------------------------------------------------------------------------------
-#define ISBITMASK( r,g,b,a ) ( ddpf.dwRBitMask == r && ddpf.dwGBitMask == g && ddpf.dwBBitMask == b && ddpf.dwABitMask == a )
+#define ISBITMASK( r,g,b,a ) ( ddpf.RBitMask == r && ddpf.GBitMask == g && ddpf.BBitMask == b && ddpf.ABitMask == a )
 
 //--------------------------------------------------------------------------------------
 static D3DFORMAT GetD3D9Format( const DDS_PIXELFORMAT& ddpf )
 {
-    if( ddpf.dwFlags & DDS_RGB )
+    if( ddpf.flags & DDS_RGB )
     {
-        switch (ddpf.dwRGBBitCount)
+        switch (ddpf.RGBBitCount)
         {
         case 32:
             if( ISBITMASK(0x00ff0000,0x0000ff00,0x000000ff,0xff000000) )
@@ -551,60 +555,128 @@ static D3DFORMAT GetD3D9Format( const DDS_PIXELFORMAT& ddpf )
             if( ISBITMASK(0x00000f00,0x000000f0,0x0000000f,0x00000000) )
                 return D3DFMT_X4R4G4B4;
 
-            // 3:3:2, 3:3:2:8, and paletted texture formats are typically not supported on modern video cards
-            break;
-        }
-    }
-    else if( ddpf.dwFlags & DDS_LUMINANCE )
-    {
-        if( 8 == ddpf.dwRGBBitCount )
-        {
-            if( ISBITMASK(0x0000000f,0x00000000,0x00000000,0x000000f0) )
-                return D3DFMT_A4L4;
-            if( ISBITMASK(0x000000ff,0x00000000,0x00000000,0x00000000) )
-                return D3DFMT_L8;
-        }
+            if (ISBITMASK(0x00e0, 0x001c, 0x0003, 0xff00))
+                return D3DFMT_A8R3G3B2;
 
-        if( 16 == ddpf.dwRGBBitCount )
-        {
-            if( ISBITMASK(0x0000ffff,0x00000000,0x00000000,0x00000000) )
+            // NVTT versions 1.x wrote these as RGB instead of LUMINANCE
+            if (ISBITMASK(0xffff, 0, 0, 0))
                 return D3DFMT_L16;
-            if( ISBITMASK(0x000000ff,0x00000000,0x00000000,0x0000ff00) )
+            if (ISBITMASK(0x00ff, 0, 0, 0xff00))
                 return D3DFMT_A8L8;
+            break;
+
+        case 8:
+            if (ISBITMASK(0xe0, 0x1c, 0x03, 0))
+                return D3DFMT_R3G3B2;
+
+            // NVTT versions 1.x wrote these as RGB instead of LUMINANCE
+            if (ISBITMASK(0xff, 0, 0, 0))
+                return D3DFMT_L8;
+
+            // Paletted texture formats are typically not supported on modern video cards aka D3DFMT_P8, D3DFMT_A8P8
+            break;
+
+        default:
+            return D3DFMT_UNKNOWN;
         }
     }
-    else if( ddpf.dwFlags & DDS_ALPHA )
+    else if( ddpf.flags & DDS_LUMINANCE )
     {
-        if( 8 == ddpf.dwRGBBitCount )
+        switch (ddpf.RGBBitCount)
+        {
+        case 16:
+            if (ISBITMASK(0xffff, 0, 0, 0))
+                return D3DFMT_L16;
+            if (ISBITMASK(0x00ff, 0, 0, 0xff00))
+                return D3DFMT_A8L8;
+            break;
+
+        case 8:
+            if (ISBITMASK(0x0f, 0, 0, 0xf0))
+                return D3DFMT_A4L4;
+            if (ISBITMASK(0xff, 0, 0, 0))
+                return D3DFMT_L8;
+
+            if (ISBITMASK(0x00ff, 0, 0, 0xff00))
+                return D3DFMT_A8L8; // Some DDS writers assume the bitcount should be 8 instead of 16
+            break;
+
+        default:
+            return D3DFMT_UNKNOWN;
+        }
+    }
+    else if( ddpf.flags & DDS_ALPHA )
+    {
+        if( 8 == ddpf.RGBBitCount )
         {
             return D3DFMT_A8;
         }
     }
-    else if( ddpf.dwFlags & DDS_FOURCC )
+    else if (ddpf.flags & DDS_BUMPDUDV)
     {
-        if( MAKEFOURCC( 'D', 'X', 'T', '1' ) == ddpf.dwFourCC )
+        switch (ddpf.RGBBitCount)
+        {
+        case 32:
+            if (ISBITMASK(0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000))
+                return D3DFMT_Q8W8V8U8;
+            if (ISBITMASK(0x0000ffff, 0xffff0000, 0x00000000, 0x00000000))
+                return D3DFMT_V16U16;
+            if (ISBITMASK(0x3ff00000, 0x000ffc00, 0x000003ff, 0xc0000000))
+                return D3DFMT_A2W10V10U10;
+            break;
+
+        case 16:
+            if (ISBITMASK(0x00ff, 0xff00, 0, 0))
+                return D3DFMT_V8U8;
+            break;
+
+        default:
+            return D3DFMT_UNKNOWN;
+        }
+    }
+    else if (ddpf.flags & DDS_BUMPLUMINANCE)
+    {
+        switch (ddpf.RGBBitCount)
+        {
+        case 32:
+            if (ISBITMASK(0x000000ff, 0x0000ff00, 0x00ff0000, 0))
+                return D3DFMT_X8L8V8U8;
+            break;
+
+        case 16:
+            if (ISBITMASK(0x001f, 0x03e0, 0xfc00, 0))
+                return D3DFMT_L6V5U5;
+            break;
+
+        default:
+            return D3DFMT_UNKNOWN;
+        }
+    }
+    else if( ddpf.flags & DDS_FOURCC )
+    {
+        if( MAKEFOURCC( 'D', 'X', 'T', '1' ) == ddpf.fourCC )
             return D3DFMT_DXT1;
-        if( MAKEFOURCC( 'D', 'X', 'T', '2' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'D', 'X', 'T', '2' ) == ddpf.fourCC )
             return D3DFMT_DXT2;
-        if( MAKEFOURCC( 'D', 'X', 'T', '3' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'D', 'X', 'T', '3' ) == ddpf.fourCC )
             return D3DFMT_DXT3;
-        if( MAKEFOURCC( 'D', 'X', 'T', '4' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'D', 'X', 'T', '4' ) == ddpf.fourCC )
             return D3DFMT_DXT4;
-        if( MAKEFOURCC( 'D', 'X', 'T', '5' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'D', 'X', 'T', '5' ) == ddpf.fourCC )
             return D3DFMT_DXT5;
 
-        if( MAKEFOURCC( 'R', 'G', 'B', 'G' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'R', 'G', 'B', 'G' ) == ddpf.fourCC )
             return D3DFMT_R8G8_B8G8;
-        if( MAKEFOURCC( 'G', 'R', 'G', 'B' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'G', 'R', 'G', 'B' ) == ddpf.fourCC )
             return D3DFMT_G8R8_G8B8;
 
-        if( MAKEFOURCC( 'U', 'Y', 'V', 'Y' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'U', 'Y', 'V', 'Y' ) == ddpf.fourCC )
             return D3DFMT_UYVY;
-        if( MAKEFOURCC( 'Y', 'U', 'Y', '2' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'Y', 'U', 'Y', '2' ) == ddpf.fourCC )
             return D3DFMT_YUY2;
 
         // Check for D3DFORMAT enums being set here
-        switch( ddpf.dwFourCC )
+        switch( ddpf.fourCC )
         {
         case D3DFMT_A16B16G16R16:
         case D3DFMT_Q16W16V16U16:
@@ -615,7 +687,10 @@ static D3DFORMAT GetD3D9Format( const DDS_PIXELFORMAT& ddpf )
         case D3DFMT_G32R32F:
         case D3DFMT_A32B32G32R32F:
         case D3DFMT_CxV8U8:
-            return (D3DFORMAT)ddpf.dwFourCC;
+            return static_cast<D3DFORMAT>(ddpf.fourCC);
+
+        default:
+            return D3DFMT_UNKNOWN;
         }
     }
 
@@ -625,9 +700,9 @@ static D3DFORMAT GetD3D9Format( const DDS_PIXELFORMAT& ddpf )
 //--------------------------------------------------------------------------------------
 static DXGI_FORMAT GetDXGIFormat( const DDS_PIXELFORMAT& ddpf )
 {
-    if( ddpf.dwFlags & DDS_RGB )
+    if( ddpf.flags & DDS_RGB )
     {
-        switch (ddpf.dwRGBBitCount)
+        switch (ddpf.RGBBitCount)
         {
         case 32:
             // DXGI_FORMAT_B8G8R8A8_UNORM_SRGB & DXGI_FORMAT_B8G8R8X8_UNORM_SRGB should be
@@ -656,6 +731,8 @@ static DXGI_FORMAT GetDXGIFormat( const DDS_PIXELFORMAT& ddpf )
             if( ISBITMASK(0x3ff00000,0x000ffc00,0x000003ff,0xc0000000) )
                 return DXGI_FORMAT_R10G10B10A2_UNORM;
 
+            // No DXGI format maps to ISBITMASK(0x000003ff,0x000ffc00,0x3ff00000,0xc0000000) aka D3DFMT_A2R10G10B10
+
             if( ISBITMASK(0x0000ffff,0xffff0000,0x00000000,0x00000000) )
                 return DXGI_FORMAT_R16G16_UNORM;
 
@@ -669,74 +746,105 @@ static DXGI_FORMAT GetDXGIFormat( const DDS_PIXELFORMAT& ddpf )
             break;
 
         case 16:
-            // 5:5:5 & 5:6:5 formats are defined for DXGI, but are deprecated for D3D10, 10.0, and 11
+            // 5:5:5 & 5:6:5 formats are defined for DXGI, but are deprecated for D3D10, 10.x
 
-            // No 4bpp, 3:3:2, 3:3:2:8, or paletted DXGI formats
+            // No 4bpp, 3:3:2, 3:3:2:8, or paletted DXGI formats for 10.x
             break;
         }
     }
-    else if( ddpf.dwFlags & DDS_LUMINANCE )
+    else if( ddpf.flags & DDS_LUMINANCE )
     {
-        if( 8 == ddpf.dwRGBBitCount )
+        switch (ddpf.RGBBitCount)
         {
-            if( ISBITMASK(0x000000ff,0x00000000,0x00000000,0x00000000) )
+        case 16:
+            if (ISBITMASK(0xffff, 0, 0, 0))
+                return DXGI_FORMAT_R16_UNORM; // D3DX10/11 writes this out as DX10 extension
+            if (ISBITMASK(0x00ff, 0, 0, 0xff00))
+                return DXGI_FORMAT_R8G8_UNORM; // D3DX10/11 writes this out as DX10 extension
+            break;
+
+        case 8:
+            if (ISBITMASK(0xff, 0, 0, 0))
                 return DXGI_FORMAT_R8_UNORM; // D3DX10/11 writes this out as DX10 extension
 
-            // No 4bpp DXGI formats
-        }
+            if (ISBITMASK(0x00ff, 0, 0, 0xff00))
+                return DXGI_FORMAT_R8G8_UNORM; // Some DDS writers assume the bitcount should be 8 instead of 16
 
-        if( 16 == ddpf.dwRGBBitCount )
-        {
-            if( ISBITMASK(0x0000ffff,0x00000000,0x00000000,0x00000000) )
-                return DXGI_FORMAT_R16_UNORM; // D3DX10/11 writes this out as DX10 extension
-            if( ISBITMASK(0x000000ff,0x00000000,0x00000000,0x0000ff00) )
-                return DXGI_FORMAT_R8G8_UNORM; // D3DX10/11 writes this out as DX10 extension
+            // No 4bpp DXGI formats for 10.x
+            break;
+
+        default:
+            return DXGI_FORMAT_UNKNOWN;
         }
     }
-    else if( ddpf.dwFlags & DDS_ALPHA )
+    else if( ddpf.flags & DDS_ALPHA )
     {
-        if( 8 == ddpf.dwRGBBitCount )
+        if( 8 == ddpf.RGBBitCount )
         {
             return DXGI_FORMAT_A8_UNORM;
         }
     }
-    else if( ddpf.dwFlags & DDS_FOURCC )
+    else if (ddpf.flags & DDS_BUMPDUDV)
     {
-        if( MAKEFOURCC( 'D', 'X', 'T', '1' ) == ddpf.dwFourCC )
+        switch (ddpf.RGBBitCount)
+        {
+        case 32:
+            if (ISBITMASK(0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000))
+                return DXGI_FORMAT_R8G8B8A8_SNORM; // D3DX10/11 writes this out as DX10 extension
+            if (ISBITMASK(0x0000ffff, 0xffff0000, 0, 0))
+                return DXGI_FORMAT_R16G16_SNORM; // D3DX10/11 writes this out as DX10 extension
+
+            // No DXGI format maps to ISBITMASK(0x3ff00000, 0x000ffc00, 0x000003ff, 0xc0000000) aka D3DFMT_A2W10V10U10
+            break;
+
+        case 16:
+            if (ISBITMASK(0x00ff, 0xff00, 0, 0))
+                return DXGI_FORMAT_R8G8_SNORM; // D3DX10/11 writes this out as DX10 extension
+            break;
+
+        default:
+            return DXGI_FORMAT_UNKNOWN;
+        }
+
+        // No DXGI format maps to DDPF_BUMPLUMINANCE aka D3DFMT_L6V5U5, D3DFMT_X8L8V8U8
+    }
+    else if( ddpf.flags & DDS_FOURCC )
+    {
+        if( MAKEFOURCC( 'D', 'X', 'T', '1' ) == ddpf.fourCC )
             return DXGI_FORMAT_BC1_UNORM;
-        if( MAKEFOURCC( 'D', 'X', 'T', '3' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'D', 'X', 'T', '3' ) == ddpf.fourCC )
             return DXGI_FORMAT_BC2_UNORM;
-        if( MAKEFOURCC( 'D', 'X', 'T', '5' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'D', 'X', 'T', '5' ) == ddpf.fourCC )
             return DXGI_FORMAT_BC3_UNORM;
 
         // While pre-mulitplied alpha isn't directly supported by the DXGI formats,
         // they are basically the same as these BC formats so they can be mapped
-        if( MAKEFOURCC( 'D', 'X', 'T', '2' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'D', 'X', 'T', '2' ) == ddpf.fourCC )
             return DXGI_FORMAT_BC2_UNORM;
-        if( MAKEFOURCC( 'D', 'X', 'T', '4' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'D', 'X', 'T', '4' ) == ddpf.fourCC )
             return DXGI_FORMAT_BC3_UNORM;
 
-        if( MAKEFOURCC( 'A', 'T', 'I', '1' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'A', 'T', 'I', '1' ) == ddpf.fourCC )
             return DXGI_FORMAT_BC4_UNORM;
-        if( MAKEFOURCC( 'B', 'C', '4', 'U' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'B', 'C', '4', 'U' ) == ddpf.fourCC )
             return DXGI_FORMAT_BC4_UNORM;
-        if( MAKEFOURCC( 'B', 'C', '4', 'S' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'B', 'C', '4', 'S' ) == ddpf.fourCC )
             return DXGI_FORMAT_BC4_SNORM;
 
-        if( MAKEFOURCC( 'A', 'T', 'I', '2' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'A', 'T', 'I', '2' ) == ddpf.fourCC )
             return DXGI_FORMAT_BC5_UNORM;
-        if( MAKEFOURCC( 'B', 'C', '5', 'U' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'B', 'C', '5', 'U' ) == ddpf.fourCC )
             return DXGI_FORMAT_BC5_UNORM;
-        if( MAKEFOURCC( 'B', 'C', '5', 'S' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'B', 'C', '5', 'S' ) == ddpf.fourCC )
             return DXGI_FORMAT_BC5_SNORM;
 
-        if( MAKEFOURCC( 'R', 'G', 'B', 'G' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'R', 'G', 'B', 'G' ) == ddpf.fourCC )
             return DXGI_FORMAT_R8G8_B8G8_UNORM;
-        if( MAKEFOURCC( 'G', 'R', 'G', 'B' ) == ddpf.dwFourCC )
+        if( MAKEFOURCC( 'G', 'R', 'G', 'B' ) == ddpf.fourCC )
             return DXGI_FORMAT_G8R8_G8B8_UNORM;
 
         // Check for D3DFORMAT enums being set here
-        switch( ddpf.dwFourCC )
+        switch( ddpf.fourCC )
         {
         case D3DFMT_A16B16G16R16: // 36
             return DXGI_FORMAT_R16G16B16A16_UNORM;
@@ -761,6 +869,11 @@ static DXGI_FORMAT GetDXGIFormat( const DDS_PIXELFORMAT& ddpf )
 
         case D3DFMT_A32B32G32R32F: // 116
             return DXGI_FORMAT_R32G32B32A32_FLOAT;
+
+            // No DXGI format maps to D3DFMT_CxV8U8
+
+        default:
+            return DXGI_FORMAT_UNKNOWN;
         }
     }
 
@@ -773,11 +886,11 @@ static HRESULT CreateTextureFromDDS( LPDIRECT3DDEVICE9 pDev, DDS_HEADER* pHeader
                                      __out LPDIRECT3DBASETEXTURE9* ppTex )
 {
     HRESULT hr = S_OK;
-    
-    UINT iWidth = pHeader->dwWidth;
-    UINT iHeight = pHeader->dwHeight;
 
-    UINT iMipCount = pHeader->dwMipMapCount;
+    UINT iWidth = pHeader->width;
+    UINT iHeight = pHeader->height;
+
+    UINT iMipCount = pHeader->mipMapCount;
     if( 0 == iMipCount )
         iMipCount = 1;
 
@@ -788,9 +901,9 @@ static HRESULT CreateTextureFromDDS( LPDIRECT3DDEVICE9 pDev, DDS_HEADER* pHeader
     if ( fmt == D3DFMT_UNKNOWN || BitsPerPixel( fmt ) == 0 )
         return HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED );
 
-    if ( pHeader->dwFlags & DDS_HEADER_FLAGS_VOLUME )
+    if ( pHeader->flags & DDS_HEADER_FLAGS_VOLUME )
     {
-        UINT iDepth = pHeader->dwDepth;
+        UINT iDepth = pHeader->depth;
 
         // Create the volume texture (let the runtime do the validation)
         LPDIRECT3DVOLUMETEXTURE9 pTexture;
@@ -812,7 +925,7 @@ static HRESULT CreateTextureFromDDS( LPDIRECT3DDEVICE9 pDev, DDS_HEADER* pHeader
         UINT NumBytes, RowBytes, NumRows;
         const BYTE* pSrcBits = pBitData;
         const BYTE *pEndBits = pBitData + BitSize;
-        D3DLOCKED_BOX LockedBox = {0};
+        D3DLOCKED_BOX LockedBox = {};
 
         for( UINT i = 0; i < iMipCount; ++i )
         {
@@ -870,10 +983,10 @@ static HRESULT CreateTextureFromDDS( LPDIRECT3DDEVICE9 pDev, DDS_HEADER* pHeader
 
         *ppTex = pTexture;
     }
-    else if ( pHeader->dwCaps2 & DDS_CUBEMAP )
+    else if ( pHeader->caps2 & DDS_CUBEMAP )
     {
         // We require at least one face to be defined, and the faces must be square
-        if ( (pHeader->dwCaps2 & DDS_CUBEMAP_ALLFACES ) == 0 || iHeight != iWidth )
+        if ( (pHeader->caps2 & DDS_CUBEMAP_ALLFACES ) == 0 || iHeight != iWidth )
             return HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED );
 
         // Create the cubemap (let the runtime do the validation)
@@ -896,12 +1009,12 @@ static HRESULT CreateTextureFromDDS( LPDIRECT3DDEVICE9 pDev, DDS_HEADER* pHeader
         UINT NumBytes, RowBytes, NumRows;
         const BYTE* pSrcBits = pBitData;
         const BYTE *pEndBits = pBitData + BitSize;
-        D3DLOCKED_RECT LockedRect = {0};
+        D3DLOCKED_RECT LockedRect = {};
 
         UINT mask = DDS_CUBEMAP_POSITIVEX & ~DDS_CUBEMAP;
         for( UINT f = 0; f < 6; ++f, mask <<= 1 )
         {
-            if( !(pHeader->dwCaps2 & mask ) )
+            if( !(pHeader->caps2 & mask ) )
                 continue;
 
             UINT w = iWidth;
@@ -973,7 +1086,7 @@ static HRESULT CreateTextureFromDDS( LPDIRECT3DDEVICE9 pDev, DDS_HEADER* pHeader
         UINT NumBytes, RowBytes, NumRows;
         const BYTE* pSrcBits = pBitData;
         const BYTE *pEndBits = pBitData + BitSize;
-        D3DLOCKED_RECT LockedRect = {0};
+        D3DLOCKED_RECT LockedRect = {};
 
         for( UINT i = 0; i < iMipCount; ++i )
         {
@@ -1030,24 +1143,24 @@ static HRESULT CreateTextureFromDDS( ID3D10Device1* pDev, DDS_HEADER* pHeader, _
 {
     HRESULT hr = S_OK;
 
-    UINT iWidth = pHeader->dwWidth;
-    UINT iHeight = pHeader->dwHeight;
-    UINT iDepth = pHeader->dwDepth;
+    UINT iWidth = pHeader->width;
+    UINT iHeight = pHeader->height;
+    UINT iDepth = pHeader->depth;
 
     UINT resDim = D3D10_RESOURCE_DIMENSION_UNKNOWN;
     UINT arraySize = 1;
     DXGI_FORMAT format = DXGI_FORMAT_UNKNOWN;
     bool isCubeMap = false;
 
-    UINT iMipCount = pHeader->dwMipMapCount;
+    UINT iMipCount = pHeader->mipMapCount;
     if( 0 == iMipCount )
         iMipCount = 1;
 
     bool swaprgb = false;
     bool seta = false;
 
-    if ((pHeader->ddspf.dwFlags & DDS_FOURCC)
-        && (MAKEFOURCC( 'D', 'X', '1', '0' ) == pHeader->ddspf.dwFourCC ) )
+    if ((pHeader->ddspf.flags & DDS_FOURCC)
+        && (MAKEFOURCC( 'D', 'X', '1', '0' ) == pHeader->ddspf.fourCC ) )
     {
         DDS_HEADER_DXT10* d3d10ext = (DDS_HEADER_DXT10*)( (char*)pHeader + sizeof(DDS_HEADER) );
 
@@ -1057,14 +1170,14 @@ static HRESULT CreateTextureFromDDS( ID3D10Device1* pDev, DDS_HEADER* pHeader, _
 
         if ( BitsPerPixel( d3d10ext->dxgiFormat ) == 0 )
             return HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED );
-           
+
         format = d3d10ext->dxgiFormat;
 
         switch ( d3d10ext->resourceDimension )
         {
         case DDS_DIMENSION_TEXTURE1D:
             // D3DX writes 1D textures with a fixed Height of 1
-            if ( (pHeader->dwFlags & DDS_HEIGHT) && iHeight != 1 )
+            if ( (pHeader->flags & DDS_HEIGHT) && iHeight != 1 )
                 return HRESULT_FROM_WIN32( ERROR_INVALID_DATA );
             iHeight = iDepth = 1;
             break;
@@ -1079,7 +1192,7 @@ static HRESULT CreateTextureFromDDS( ID3D10Device1* pDev, DDS_HEADER* pHeader, _
             break;
 
         case DDS_DIMENSION_TEXTURE3D:
-            if ( !(pHeader->dwFlags & DDS_HEADER_FLAGS_VOLUME) )
+            if ( !(pHeader->flags & DDS_HEADER_FLAGS_VOLUME) )
                 return HRESULT_FROM_WIN32( ERROR_INVALID_DATA );
 
             if ( arraySize > 1 )
@@ -1096,16 +1209,16 @@ static HRESULT CreateTextureFromDDS( ID3D10Device1* pDev, DDS_HEADER* pHeader, _
     {
         format = GetDXGIFormat( pHeader->ddspf );
 
-        if ( pHeader->dwFlags & DDS_HEADER_FLAGS_VOLUME )
+        if ( pHeader->flags & DDS_HEADER_FLAGS_VOLUME )
         {
             resDim = DDS_DIMENSION_TEXTURE3D;
         }
-        else 
+        else
         {
-            if ( pHeader->dwCaps2 & DDS_CUBEMAP )
+            if ( pHeader->caps2 & DDS_CUBEMAP )
             {
                // We require all six faces to be defined
-               if ( (pHeader->dwCaps2 & DDS_CUBEMAP_ALLFACES ) != DDS_CUBEMAP_ALLFACES )
+               if ( (pHeader->caps2 & DDS_CUBEMAP_ALLFACES ) != DDS_CUBEMAP_ALLFACES )
                    return HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED );
 
                 arraySize = 6;
@@ -1174,12 +1287,12 @@ static HRESULT CreateTextureFromDDS( ID3D10Device1* pDev, DDS_HEADER* pHeader, _
             {
                 // This is the right bound because we set arraySize to (NumCubes*6) above
                 if ( (arraySize > D3D10_REQ_TEXTURECUBE_DIMENSION)
-                     || (iWidth > D3D10_REQ_TEXTURECUBE_DIMENSION) 
+                     || (iWidth > D3D10_REQ_TEXTURECUBE_DIMENSION)
                      || (iHeight > D3D10_REQ_TEXTURECUBE_DIMENSION))
                     return HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED );
             }
             else if ( (arraySize > D3D10_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION)
-                 || (iWidth > D3D10_REQ_TEXTURE2D_U_OR_V_DIMENSION) 
+                 || (iWidth > D3D10_REQ_TEXTURE2D_U_OR_V_DIMENSION)
                  || (iHeight > D3D10_REQ_TEXTURE2D_U_OR_V_DIMENSION))
             {
                 return HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED );
@@ -1188,14 +1301,14 @@ static HRESULT CreateTextureFromDDS( ID3D10Device1* pDev, DDS_HEADER* pHeader, _
 
         case DDS_DIMENSION_TEXTURE3D:
             if ( (arraySize > 1)
-                 || (iWidth > D3D10_REQ_TEXTURE3D_U_V_OR_W_DIMENSION) 
+                 || (iWidth > D3D10_REQ_TEXTURE3D_U_V_OR_W_DIMENSION)
                  || (iHeight > D3D10_REQ_TEXTURE3D_U_V_OR_W_DIMENSION)
                  || (iDepth > D3D10_REQ_TEXTURE3D_U_V_OR_W_DIMENSION) )
                 return HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED );
             break;
         }
 
-    
+
     if ( bSRGB )
         format = MAKE_SRGB( format );
 
@@ -1261,7 +1374,7 @@ static HRESULT CreateTextureFromDDS( ID3D10Device1* pDev, DDS_HEADER* pHeader, _
                                 rptr += RowBytes;
                             }
                             sptr += NumBytes;
-                        }           
+                        }
                     }
                     break;
 
@@ -1281,18 +1394,18 @@ static HRESULT CreateTextureFromDDS( ID3D10Device1* pDev, DDS_HEADER* pHeader, _
                                         DWORD t = *ptr;
                                         DWORD u = (t & 0x3ff00000) >> 20;
                                         DWORD v = (t & 0x000003ff) << 20;
-                                        *ptr = ( t & ~0x3ff003ff ) | u | v; 
+                                        *ptr = ( t & ~0x3ff003ff ) | u | v;
                                     }
                                 }
                                 rptr += RowBytes;
                             }
                             sptr += NumBytes;
-                        }           
+                        }
                     }
                     break;
                 }
             }
-    
+
             pSrcBits += NumBytes * d;
 
             w = w >> 1;
@@ -1307,12 +1420,12 @@ static HRESULT CreateTextureFromDDS( ID3D10Device1* pDev, DDS_HEADER* pHeader, _
         }
     }
 
-    switch ( resDim ) 
+    switch ( resDim )
     {
         case DDS_DIMENSION_TEXTURE1D:
             {
                 D3D10_TEXTURE1D_DESC desc;
-                desc.Width = iWidth; 
+                desc.Width = iWidth;
                 desc.MipLevels = iMipCount;
                 desc.ArraySize = arraySize;
                 desc.Format = format;
@@ -1440,7 +1553,7 @@ static HRESULT CreateTextureFromDDS( ID3D10Device1* pDev, DDS_HEADER* pHeader, _
                     SAFE_RELEASE( pTex );
                 }
             }
-            break; 
+            break;
     }
 
     SAFE_DELETE_ARRAY( pInitData );
@@ -1565,7 +1678,7 @@ HRESULT CreateDDSTextureFromFile( ID3D10Device1* pDev, const WCHAR* szFileName, 
             pstrName = strFileA;
         else
             pstrName++;
-        
+
         (*ppSRV)->SetPrivateData( WKPDID_D3DDebugObjectName, lstrlenA(pstrName), pstrName );
     }
 #endif

--- a/C++/Direct3D10/DDSWithoutD3DX/DDSTextureLoader.cpp
+++ b/C++/Direct3D10/DDSWithoutD3DX/DDSTextureLoader.cpp
@@ -1313,7 +1313,7 @@ static HRESULT CreateTextureFromDDS( ID3D10Device1* pDev, DDS_HEADER* pHeader, _
         format = MAKE_SRGB( format );
 
     // Create the texture
-    D3D10_SUBRESOURCE_DATA* pInitData = new D3D10_SUBRESOURCE_DATA[ iMipCount * arraySize ];
+    D3D10_SUBRESOURCE_DATA* pInitData = new (std::nothrow) D3D10_SUBRESOURCE_DATA[ iMipCount * arraySize ];
     if( !pInitData )
         return E_OUTOFMEMORY;
 

--- a/C++/Direct3D11/DDSWithoutD3DX11/DDSTextureLoader.cpp
+++ b/C++/Direct3D11/DDSWithoutD3DX11/DDSTextureLoader.cpp
@@ -361,14 +361,14 @@ static void GetSurfaceInfo( UINT width, UINT height, D3DFORMAT fmt, UINT* pNumBy
 
     // From the DXSDK docs:
     //
-    //     When computing DXTn compressed sizes for non-square textures, the 
+    //     When computing DXTn compressed sizes for non-square textures, the
     //     following formula should be used at each mipmap level:
     //
-    //         max(1, width * 4) x max(1, height * 4) x 8(DXT1) or 16(DXT2-5)
+    //         max(1, width / 4) x max(1, height / 4) x 8(DXT1) or 16(DXT2-5)
     //
-    //     The pitch for DXTn formats is different from what was returned in 
-    //     Microsoft DirectX 7.0. It now refers the pitch of a row of blocks. 
-    //     For example, if you have a width of 16, then you will have a pitch 
+    //     The pitch for DXTn formats is different from what was returned in
+    //     Microsoft DirectX 7.0. It now refers the pitch of a row of blocks.
+    //     For example, if you have a width of 16, then you will have a pitch
     //     of four blocks (4*8 for DXT1, 4*16 for DXT2-5.)"
 
     switch( fmt )
@@ -701,6 +701,10 @@ static DXGI_FORMAT GetDXGIFormat( const DDS_PIXELFORMAT& ddpf )
         switch (ddpf.RGBBitCount)
         {
         case 32:
+            // DXGI_FORMAT_B8G8R8A8_UNORM_SRGB & DXGI_FORMAT_B8G8R8X8_UNORM_SRGB should be
+            // written using the DX10 extended header instead since these formats require
+            // DXGI 1.1
+            //
             // This code will use the fallback to swizzle BGR to RGB in memory for standard
             // DDS files which works on 10 and 10.1 devices with WDDM 1.0 drivers
             //
@@ -916,7 +920,7 @@ static HRESULT CreateTextureFromDDS( LPDIRECT3DDEVICE9 pDev, DDS_HEADER* pHeader
                                      __out LPDIRECT3DBASETEXTURE9* ppTex )
 {
     HRESULT hr = S_OK;
-    
+
     UINT iWidth = pHeader->width;
     UINT iHeight = pHeader->height;
 
@@ -1200,7 +1204,7 @@ static HRESULT CreateTextureFromDDS( ID3D11Device* pDev, DDS_HEADER* pHeader, __
 
         if ( BitsPerPixel( d3d10ext->dxgiFormat ) == 0 )
             return HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED );
-           
+
         format = d3d10ext->dxgiFormat;
 
         switch ( d3d10ext->resourceDimension )
@@ -1243,7 +1247,7 @@ static HRESULT CreateTextureFromDDS( ID3D11Device* pDev, DDS_HEADER* pHeader, __
         {
             resDim = DDS_DIMENSION_TEXTURE3D;
         }
-        else 
+        else
         {
             if ( pHeader->caps2 & DDS_CUBEMAP )
             {
@@ -1317,12 +1321,12 @@ static HRESULT CreateTextureFromDDS( ID3D11Device* pDev, DDS_HEADER* pHeader, __
             {
                 // This is the right bound because we set arraySize to (NumCubes*6) above
                 if ( (arraySize > D3D11_REQ_TEXTURECUBE_DIMENSION)
-                     || (iWidth > D3D11_REQ_TEXTURECUBE_DIMENSION) 
+                     || (iWidth > D3D11_REQ_TEXTURECUBE_DIMENSION)
                      || (iHeight > D3D11_REQ_TEXTURECUBE_DIMENSION))
                     return HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED );
             }
             else if ( (arraySize > D3D11_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION)
-                 || (iWidth > D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION) 
+                 || (iWidth > D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION)
                  || (iHeight > D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION))
             {
                 return HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED );
@@ -1331,14 +1335,14 @@ static HRESULT CreateTextureFromDDS( ID3D11Device* pDev, DDS_HEADER* pHeader, __
 
         case DDS_DIMENSION_TEXTURE3D:
             if ( (arraySize > 1)
-                 || (iWidth > D3D11_REQ_TEXTURE3D_U_V_OR_W_DIMENSION) 
+                 || (iWidth > D3D11_REQ_TEXTURE3D_U_V_OR_W_DIMENSION)
                  || (iHeight > D3D11_REQ_TEXTURE3D_U_V_OR_W_DIMENSION)
                  || (iDepth > D3D11_REQ_TEXTURE3D_U_V_OR_W_DIMENSION) )
                 return HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED );
             break;
         }
 
-    
+
     if ( bSRGB )
         format = MAKE_SRGB( format );
 
@@ -1404,7 +1408,7 @@ static HRESULT CreateTextureFromDDS( ID3D11Device* pDev, DDS_HEADER* pHeader, __
                                 rptr += RowBytes;
                             }
                             sptr += NumBytes;
-                        }           
+                        }
                     }
                     break;
 
@@ -1424,18 +1428,18 @@ static HRESULT CreateTextureFromDDS( ID3D11Device* pDev, DDS_HEADER* pHeader, __
                                         DWORD t = *ptr;
                                         DWORD u = (t & 0x3ff00000) >> 20;
                                         DWORD v = (t & 0x000003ff) << 20;
-                                        *ptr = ( t & ~0x3ff003ff ) | u | v; 
+                                        *ptr = ( t & ~0x3ff003ff ) | u | v;
                                     }
                                 }
                                 rptr += RowBytes;
                             }
                             sptr += NumBytes;
-                        }           
+                        }
                     }
                     break;
                 }
             }
-    
+
             pSrcBits += NumBytes * d;
 
             w = w >> 1;
@@ -1450,12 +1454,12 @@ static HRESULT CreateTextureFromDDS( ID3D11Device* pDev, DDS_HEADER* pHeader, __
         }
     }
 
-    switch ( resDim ) 
+    switch ( resDim )
     {
         case DDS_DIMENSION_TEXTURE1D:
             {
                 D3D11_TEXTURE1D_DESC desc;
-                desc.Width = iWidth; 
+                desc.Width = iWidth;
                 desc.MipLevels = iMipCount;
                 desc.ArraySize = arraySize;
                 desc.Format = format;
@@ -1583,7 +1587,7 @@ static HRESULT CreateTextureFromDDS( ID3D11Device* pDev, DDS_HEADER* pHeader, __
                     SAFE_RELEASE( pTex );
                 }
             }
-            break; 
+            break;
     }
 
     SAFE_DELETE_ARRAY( pInitData );
@@ -1708,7 +1712,7 @@ HRESULT CreateDDSTextureFromFile( ID3D11Device* pDev, const WCHAR* szFileName, I
             pstrName = strFileA;
         else
             pstrName++;
-        
+
         (*ppSRV)->SetPrivateData( WKPDID_D3DDebugObjectName, lstrlenA(pstrName), pstrName );
     }
 #endif

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The DirectX SDK itself is deprecated and legacy per [Microsoft Docs](https://lea
 |DirectX Capabilities Viewer| See [DxCapsViewer](https://github.com/microsoft/DxCapsViewer).|https://github.com/walbourn/directx-sdk-legacy-samples.git
 |UVAtlas isochart texture atlas| See [UVAtlas](https://github.com/Microsoft/UVAtlas).|
 
+## Documentation
+
+A catalog of samples can be found on the project [wiki](https://github.com/microsoft/DirectX-SDK-Samples/wiki).
+
 ## Release Notes
 
 FOR SECURITY ADVISORIES, see [GitHub](https://github.com/microsoft/DirectX-SDK-Samples/security/advisories).
@@ -30,6 +34,8 @@ FOR SECURITY ADVISORIES, see [GitHub](https://github.com/microsoft/DirectX-SDK-S
 For a full change history, see [CHANGELOG.md](https://github.com/microsoft/DirectX-SDK-Samples/blob/main/CHANGELOG.md).
 
 * The XInput samples have been updated to use XInput 1.4 or XInput 9.1.0. XInput 1.3 usage requires the legacy DirectX SDK and is *strongly discouraged*.
+
+* The XAudio2 samples have been updated to use XAudio 2.9 built into Windows 10/Windows 11 or via [XAudio2Redist](https://aka.ms/XAudio2Redist).
 
 * The XACT samples are not included in this repository because they will only build with the legacy DirectX SDK.
 
@@ -46,6 +52,12 @@ For a full change history, see [CHANGELOG.md](https://github.com/microsoft/Direc
    1. "DXUT11.1" is a Direct3D 11 only version that does not make use of legacy D3DX which shipped on [GitHub](https://github.com/microsoft/DXUT).
 
 * The version of Effects for Direct3D 11 included in this repository matches the updated version which shipped on [GitHub](https://github.com/microsoft/FX11). Note that the required `fx_*` profiles for the HLSL compiler are deprecated.
+
+## Contributing
+
+This project is largely a historical reference of the legacy DirectX SDK samples with some modernization over the past decade. There's no *Issues* tab as the content is largely provided "as is". PRs for critical fixes, in particular security issues, are welcome.
+
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
 
 ## Code of Conduct
 


### PR DESCRIPTION
I had updated the Direct3D 11 version of DDSWithoutD3DX to match the latest changes for DDSTextureLoader in other projects, but forgot to update the Direct3D 10 version.