### PR TITLE
Add a command script to build and copy binaries to bin folders

### DIFF
--- a/BuildAllSolutions.targets
+++ b/BuildAllSolutions.targets
@@ -37,4 +37,17 @@
     <MSBuild Projects="$(_OneSln)"
       Properties="Configuration=$(Configuration);Platform=$(Platform)" />
   </Target>
+
+<Target Name="Clean"
+    Outputs="%(FullSolutionList.Identity)">
+
+    <PropertyGroup>
+      <_OneSln>%(FullSolutionList.Identity)</_OneSln>
+    </PropertyGroup>
+
+    <MSBuild Projects="$(_OneSln)"
+      Properties="Configuration=$(Configuration);Platform=$(Platform)"
+      Targets="Clean" />
+  </Target>
 </Project>
+

--- a/MakeDeploy.cmd
+++ b/MakeDeploy.cmd
@@ -59,6 +59,7 @@ copy /y BasicHLSL11\x64\Release\d3dx11_43.dll "bin\x64" >NUL
 @if ERRORLEVEL 1 goto error
 for /R %%1 in (Release\*.exe) do copy /y "%%1" "bin\x64\%%~nx1" >NUL
 @if ERRORLEVEL 1 goto error
+del /q "bin\x64\Tutorial*.exe"
 popd
 REM XAudio2
 pushd "C++\XAudio2"

--- a/MakeDeploy.cmd
+++ b/MakeDeploy.cmd
@@ -105,6 +105,7 @@ for /R %%1 in (Release\*.exe) do copy /y "%%1" "bin\x64\%%~nx1" >NUL
 @if ERRORLEVEL 1 goto error
 popd
 @echo --- DEPLOY COMPLETE ---
+msbuild BuildAllSolutions.targets /v:q /p:Configuration=Release /p:Platform=x64 /t:Clean
 @goto end
 :error
 @echo --- ERROR: FAILED ---

--- a/MakeDeploy.cmd
+++ b/MakeDeploy.cmd
@@ -1,0 +1,111 @@
+@echo off
+echo .
+echo First builds all the samples
+echo .
+echo Then creates 'bin' folders for each area (only contains x64 versions)
+echo .
+pause
+set LOG_DIR=%cd%
+set MSB_LOGGING=/fl1 /fl2 /fl3 /flp1:logfile=%LOG_DIR%\build.log;append=true /flp2:logfile=%LOG_DIR%\build.err;errorsonly;append=true /flp3:logfile=%LOG_DIR%\build.wrn;warningsonly;append=true
+del build.log
+del build.err
+del build.wrn
+msbuild BuildAllSolutions.targets /p:Configuration=Release /p:Platform=x64 %MSB_LOGGING%
+@if ERRORLEVEL 1 goto error
+@echo --- BUILD COMPLETE ---
+type build.wrn
+@echo --- DEPLOY ---
+rd /q /s "C++\Direct3D\bin"
+rd /q /s "C++\Direct3D10\bin"
+rd /q /s "C++\Direct3D11\bin"
+rd /q /s "C++\XAudio2\bin"
+rd /q /s "C++\XInput\bin"
+rd /q /s "C++\Misc\bin"
+rd /q /s "C++\DirectInput\bin"
+rd /q /s "C++\DirectSound\bin"
+REM Direct3D
+pushd "C++\Direct3D"
+md bin\x64
+copy /y BasicHLSL\x64\Release\D3DCompiler_43.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+copy /y BasicHLSL\x64\Release\d3dx9_43.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+copy /y BasicHLSL\x64\Release\d3dx10_43.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+for /R %%1 in (Release\*.exe) do copy /y "%%1" "bin\x64\%%~nx1" >NUL
+@if ERRORLEVEL 1 goto error
+popd
+REM Direct3D10
+pushd "C++\Direct3D10"
+md bin\x64
+copy /y BasicHLSL10\x64\Release\D3DCompiler_43.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+copy /y BasicHLSL10\x64\Release\d3dx9_43.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+copy /y BasicHLSL10\x64\Release\d3dx10_43.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+for /R %%1 in (Release\*.exe) do copy /y "%%1" "bin\x64\%%~nx1" >NUL
+@if ERRORLEVEL 1 goto error
+popd
+popd
+REM Direct3D11
+pushd "C++\Direct3D11"
+md bin\x64
+copy /y BasicHLSL11\x64\Release\D3DCompiler_43.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+copy /y BasicHLSL11\x64\Release\d3dx9_43.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+copy /y BasicHLSL11\x64\Release\d3dx11_43.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+for /R %%1 in (Release\*.exe) do copy /y "%%1" "bin\x64\%%~nx1" >NUL
+@if ERRORLEVEL 1 goto error
+popd
+REM XAudio2
+pushd "C++\XAudio2"
+md bin\x64
+copy XAudio2BasicSound\x64\Release_NuGet\xaudio2_9redist.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+for /R %%1 in (Release_NuGet\*.exe) do copy /y "%%1" "bin\x64\%%~nx1" >NUL
+@if ERRORLEVEL 1 goto error
+popd
+REM XInput
+pushd "C++\XInput"
+md bin\x64
+copy /y x64\Release\D3DCompiler_43.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+copy /y x64\Release\d3dx9_43.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+copy /y x64\Release\d3dx10_43.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+for /R %%1 in (Release\*.exe) do copy /y "%%1" "bin\x64\%%~nx1" >NUL
+@if ERRORLEVEL 1 goto error
+popd
+REM Misc
+pushd "C++\Misc"
+md bin\x64
+copy /y InstallOnDemand\x64\Release\D3DCompiler_43.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+copy /y InstallOnDemand\x64\Release\d3dx9_43.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+copy /y InstallOnDemand\x64\Release\d3dx10_43.dll "bin\x64" >NUL
+@if ERRORLEVEL 1 goto error
+for /R %%1 in (Release\*.exe) do copy /y "%%1" "bin\x64\%%~nx1" >NUL
+@if ERRORLEVEL 1 goto error
+popd
+REM DirectInput
+pushd "C++\DirectInput"
+md bin\x64
+for /R %%1 in (Release\*.exe) do copy /y "%%1" "bin\x64\%%~nx1" >NUL
+@if ERRORLEVEL 1 goto error
+popd
+REM DirectSound
+pushd "C++\DirectSound"
+md bin\x64
+for /R %%1 in (Release\*.exe) do copy /y "%%1" "bin\x64\%%~nx1" >NUL
+@if ERRORLEVEL 1 goto error
+popd
+@echo --- DEPLOY COMPLETE ---
+@goto end
+:error
+@echo --- ERROR: FAILED ---
+:end


### PR DESCRIPTION
From a *x64 Native Tools Visual Studio Developer Command Prompt*, this script will build all the samples and then copy the binaries to mimic the 'installed' version of the legacy DirectX SDK.

The samples will need both the source tree where they find their individual shader files and the Media shared folder. You don't need the individual Release folders so the script does a `Clean` at the end.