### PR TITLE
Code review for Direct3D 11/11 tutorials

### DIFF
--- a/C++/Direct3D10/Tutorials/Tutorial00/Tutorial00.cpp
+++ b/C++/Direct3D10/Tutorials/Tutorial00/Tutorial00.cpp
@@ -13,8 +13,8 @@
 //--------------------------------------------------------------------------------------
 // Global Variables
 //--------------------------------------------------------------------------------------
-HINSTANCE   g_hInst = NULL;
-HWND        g_hWnd = NULL;
+HINSTANCE   g_hInst = nullptr;
+HWND        g_hWnd = nullptr;
 
 
 //--------------------------------------------------------------------------------------
@@ -37,14 +37,14 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
         return 0;
 
     // Main message loop
-    MSG msg = {0};
-    while( GetMessage( &msg, NULL, 0, 0 ) )
+    MSG msg = {};
+    while( GetMessage( &msg, nullptr, 0, 0 ) )
     {
         TranslateMessage( &msg );
         DispatchMessage( &msg );
     }
 
-    return ( int )msg.wParam;
+    return static_cast<int>(msg.wParam);
 }
 
 
@@ -54,17 +54,15 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
 HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
 {
     // Register class
-    WNDCLASSEX wcex;
+    WNDCLASSEX wcex = {};
     wcex.cbSize = sizeof( WNDCLASSEX );
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon( hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
-    wcex.hCursor = LoadCursor( NULL, IDC_ARROW );
+    wcex.hCursor = LoadCursor( nullptr, IDC_ARROW );
     wcex.hbrBackground = ( HBRUSH )( COLOR_WINDOW + 1 );
-    wcex.lpszMenuName = NULL;
+    wcex.lpszMenuName = nullptr;
     wcex.lpszClassName = L"TutorialWindowClass";
     wcex.hIconSm = LoadIcon( wcex.hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
     if( !RegisterClassEx( &wcex ) )
@@ -75,8 +73,8 @@ HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
     RECT rc = { 0, 0, 640, 480 };
     AdjustWindowRect( &rc, WS_OVERLAPPEDWINDOW, FALSE );
     g_hWnd = CreateWindow( L"TutorialWindowClass", L"Direct3D 10 Tutorial 0: Setting Up Window", WS_OVERLAPPEDWINDOW,
-                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, NULL, NULL, hInstance,
-                           NULL );
+                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, nullptr, nullptr, hInstance,
+                           nullptr );
     if( !g_hWnd )
         return E_FAIL;
 

--- a/C++/Direct3D10/Tutorials/Tutorial01/Tutorial01.cpp
+++ b/C++/Direct3D10/Tutorials/Tutorial01/Tutorial01.cpp
@@ -15,12 +15,12 @@
 //--------------------------------------------------------------------------------------
 // Global Variables
 //--------------------------------------------------------------------------------------
-HINSTANCE               g_hInst = NULL;
-HWND                    g_hWnd = NULL;
+HINSTANCE               g_hInst = nullptr;
+HWND                    g_hWnd = nullptr;
 D3D10_DRIVER_TYPE       g_driverType = D3D10_DRIVER_TYPE_NULL;
-ID3D10Device*           g_pd3dDevice = NULL;
-IDXGISwapChain*         g_pSwapChain = NULL;
-ID3D10RenderTargetView* g_pRenderTargetView = NULL;
+ID3D10Device*           g_pd3dDevice = nullptr;
+IDXGISwapChain*         g_pSwapChain = nullptr;
+ID3D10RenderTargetView* g_pRenderTargetView = nullptr;
 
 
 //--------------------------------------------------------------------------------------
@@ -52,10 +52,10 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
     }
 
     // Main message loop
-    MSG msg = {0};
+    MSG msg = {};
     while( WM_QUIT != msg.message )
     {
-        if( PeekMessage( &msg, NULL, 0, 0, PM_REMOVE ) )
+        if( PeekMessage( &msg, nullptr, 0, 0, PM_REMOVE ) )
         {
             TranslateMessage( &msg );
             DispatchMessage( &msg );
@@ -68,7 +68,7 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
 
     CleanupDevice();
 
-    return ( int )msg.wParam;
+    return static_cast<int>(msg.wParam);
 }
 
 
@@ -78,17 +78,15 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
 HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
 {
     // Register class
-    WNDCLASSEX wcex;
+    WNDCLASSEX wcex = {};
     wcex.cbSize = sizeof( WNDCLASSEX );
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon( hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
-    wcex.hCursor = LoadCursor( NULL, IDC_ARROW );
+    wcex.hCursor = LoadCursor( nullptr, IDC_ARROW );
     wcex.hbrBackground = ( HBRUSH )( COLOR_WINDOW + 1 );
-    wcex.lpszMenuName = NULL;
+    wcex.lpszMenuName = nullptr;
     wcex.lpszClassName = L"TutorialWindowClass";
     wcex.hIconSm = LoadIcon( wcex.hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
     if( !RegisterClassEx( &wcex ) )
@@ -99,8 +97,8 @@ HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
     RECT rc = { 0, 0, 640, 480 };
     AdjustWindowRect( &rc, WS_OVERLAPPEDWINDOW, FALSE );
     g_hWnd = CreateWindow( L"TutorialWindowClass", L"Direct3D 10 Tutorial 1: Direct3D 10 Basics", WS_OVERLAPPEDWINDOW,
-                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, NULL, NULL, hInstance,
-                           NULL );
+                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, nullptr, nullptr, hInstance,
+                           nullptr );
     if( !g_hWnd )
         return E_FAIL;
 
@@ -161,8 +159,7 @@ HRESULT InitDevice()
     };
     UINT numDriverTypes = sizeof( driverTypes ) / sizeof( driverTypes[0] );
 
-    DXGI_SWAP_CHAIN_DESC sd;
-    ZeroMemory( &sd, sizeof( sd ) );
+    DXGI_SWAP_CHAIN_DESC sd = {};
     sd.BufferCount = 1;
     sd.BufferDesc.Width = width;
     sd.BufferDesc.Height = height;
@@ -178,7 +175,7 @@ HRESULT InitDevice()
     for( UINT driverTypeIndex = 0; driverTypeIndex < numDriverTypes; driverTypeIndex++ )
     {
         g_driverType = driverTypes[driverTypeIndex];
-        hr = D3D10CreateDeviceAndSwapChain( NULL, g_driverType, NULL, createDeviceFlags,
+        hr = D3D10CreateDeviceAndSwapChain( nullptr, g_driverType, nullptr, createDeviceFlags,
                                             D3D10_SDK_VERSION, &sd, &g_pSwapChain, &g_pd3dDevice );
         if( SUCCEEDED( hr ) )
             break;
@@ -192,12 +189,12 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    hr = g_pd3dDevice->CreateRenderTargetView( pBackBuffer, NULL, &g_pRenderTargetView );
+    hr = g_pd3dDevice->CreateRenderTargetView( pBackBuffer, nullptr, &g_pRenderTargetView );
     pBackBuffer->Release();
     if( FAILED( hr ) )
         return hr;
 
-    g_pd3dDevice->OMSetRenderTargets( 1, &g_pRenderTargetView, NULL );
+    g_pd3dDevice->OMSetRenderTargets( 1, &g_pRenderTargetView, nullptr );
 
     // Setup the viewport
     D3D10_VIEWPORT vp;

--- a/C++/Direct3D10/Tutorials/Tutorial02/Tutorial02.cpp
+++ b/C++/Direct3D10/Tutorials/Tutorial02/Tutorial02.cpp
@@ -24,16 +24,16 @@ struct SimpleVertex
 //--------------------------------------------------------------------------------------
 // Global Variables
 //--------------------------------------------------------------------------------------
-HINSTANCE               g_hInst = NULL;
-HWND                    g_hWnd = NULL;
+HINSTANCE               g_hInst = nullptr;
+HWND                    g_hWnd = nullptr;
 D3D10_DRIVER_TYPE       g_driverType = D3D10_DRIVER_TYPE_NULL;
-ID3D10Device*           g_pd3dDevice = NULL;
-IDXGISwapChain*         g_pSwapChain = NULL;
-ID3D10RenderTargetView* g_pRenderTargetView = NULL;
-ID3D10Effect*           g_pEffect = NULL;
-ID3D10EffectTechnique*  g_pTechnique = NULL;
-ID3D10InputLayout*      g_pVertexLayout = NULL;
-ID3D10Buffer*           g_pVertexBuffer = NULL;
+ID3D10Device*           g_pd3dDevice = nullptr;
+IDXGISwapChain*         g_pSwapChain = nullptr;
+ID3D10RenderTargetView* g_pRenderTargetView = nullptr;
+ID3D10Effect*           g_pEffect = nullptr;
+ID3D10EffectTechnique*  g_pTechnique = nullptr;
+ID3D10InputLayout*      g_pVertexLayout = nullptr;
+ID3D10Buffer*           g_pVertexBuffer = nullptr;
 
 
 //--------------------------------------------------------------------------------------
@@ -65,10 +65,10 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
     }
 
     // Main message loop
-    MSG msg = {0};
+    MSG msg = {};
     while( WM_QUIT != msg.message )
     {
-        if( PeekMessage( &msg, NULL, 0, 0, PM_REMOVE ) )
+        if( PeekMessage( &msg, nullptr, 0, 0, PM_REMOVE ) )
         {
             TranslateMessage( &msg );
             DispatchMessage( &msg );
@@ -81,7 +81,7 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
 
     CleanupDevice();
 
-    return ( int )msg.wParam;
+    return static_cast<int>(msg.wParam);
 }
 
 
@@ -91,17 +91,15 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
 HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
 {
     // Register class
-    WNDCLASSEX wcex;
+    WNDCLASSEX wcex = {};
     wcex.cbSize = sizeof( WNDCLASSEX );
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon( hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
-    wcex.hCursor = LoadCursor( NULL, IDC_ARROW );
+    wcex.hCursor = LoadCursor( nullptr, IDC_ARROW );
     wcex.hbrBackground = ( HBRUSH )( COLOR_WINDOW + 1 );
-    wcex.lpszMenuName = NULL;
+    wcex.lpszMenuName = nullptr;
     wcex.lpszClassName = L"TutorialWindowClass";
     wcex.hIconSm = LoadIcon( wcex.hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
     if( !RegisterClassEx( &wcex ) )
@@ -113,8 +111,8 @@ HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
     AdjustWindowRect( &rc, WS_OVERLAPPEDWINDOW, FALSE );
     g_hWnd = CreateWindow( L"TutorialWindowClass", L"Direct3D 10 Tutorial 2: Rendering a Triangle",
                            WS_OVERLAPPEDWINDOW,
-                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, NULL, NULL, hInstance,
-                           NULL );
+                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, nullptr, nullptr, hInstance,
+                           nullptr );
     if( !g_hWnd )
         return E_FAIL;
 
@@ -148,8 +146,7 @@ HRESULT InitDevice()
     };
     UINT numDriverTypes = sizeof( driverTypes ) / sizeof( driverTypes[0] );
 
-    DXGI_SWAP_CHAIN_DESC sd;
-    ZeroMemory( &sd, sizeof( sd ) );
+    DXGI_SWAP_CHAIN_DESC sd = {};
     sd.BufferCount = 1;
     sd.BufferDesc.Width = width;
     sd.BufferDesc.Height = height;
@@ -165,7 +162,7 @@ HRESULT InitDevice()
     for( UINT driverTypeIndex = 0; driverTypeIndex < numDriverTypes; driverTypeIndex++ )
     {
         g_driverType = driverTypes[driverTypeIndex];
-        hr = D3D10CreateDeviceAndSwapChain( NULL, g_driverType, NULL, createDeviceFlags,
+        hr = D3D10CreateDeviceAndSwapChain( nullptr, g_driverType, nullptr, createDeviceFlags,
                                             D3D10_SDK_VERSION, &sd, &g_pSwapChain, &g_pd3dDevice );
         if( SUCCEEDED( hr ) )
             break;
@@ -179,12 +176,12 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    hr = g_pd3dDevice->CreateRenderTargetView( pBuffer, NULL, &g_pRenderTargetView );
+    hr = g_pd3dDevice->CreateRenderTargetView( pBuffer, nullptr, &g_pRenderTargetView );
     pBuffer->Release();
     if( FAILED( hr ) )
         return hr;
 
-    g_pd3dDevice->OMSetRenderTargets( 1, &g_pRenderTargetView, NULL );
+    g_pd3dDevice->OMSetRenderTargets( 1, &g_pRenderTargetView, nullptr );
 
     // Setup the viewport
     D3D10_VIEWPORT vp;
@@ -205,11 +202,11 @@ HRESULT InitDevice()
     // the release configuration of this program.
     dwShaderFlags |= D3D10_SHADER_DEBUG;
     #endif
-    hr = D3DX10CreateEffectFromFile( L"Tutorial02.fx", NULL, NULL, "fx_4_0", dwShaderFlags, 0,
-                                         g_pd3dDevice, NULL, NULL, &g_pEffect, NULL, NULL );
+    hr = D3DX10CreateEffectFromFile( L"Tutorial02.fx", nullptr, nullptr, "fx_4_0", dwShaderFlags, 0,
+                                         g_pd3dDevice, nullptr, nullptr, &g_pEffect, nullptr, nullptr );
     if( FAILED( hr ) )
     {
-        MessageBox( NULL,
+        MessageBox( nullptr,
                     L"The FX file cannot be located.  Please run this executable from the directory that contains the FX file.", L"Error", MB_OK );
         return hr;
     }
@@ -218,7 +215,7 @@ HRESULT InitDevice()
     g_pTechnique = g_pEffect->GetTechniqueByName( "Render" );
 
     // Define the input layout
-    D3D10_INPUT_ELEMENT_DESC layout[] =
+    const D3D10_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D10_INPUT_PER_VERTEX_DATA, 0 },
     };
@@ -232,35 +229,23 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    // Set the input layout
-    g_pd3dDevice->IASetInputLayout( g_pVertexLayout );
-
     // Create vertex buffer
-    SimpleVertex vertices[] =
+    const SimpleVertex vertices[] =
     {
         D3DXVECTOR3( 0.0f, 0.5f, 0.5f ),
         D3DXVECTOR3( 0.5f, -0.5f, 0.5f ),
         D3DXVECTOR3( -0.5f, -0.5f, 0.5f ),
     };
-    D3D10_BUFFER_DESC bd;
+    D3D10_BUFFER_DESC bd = {};
     bd.Usage = D3D10_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( SimpleVertex ) * 3;
     bd.BindFlags = D3D10_BIND_VERTEX_BUFFER;
-    bd.CPUAccessFlags = 0;
-    bd.MiscFlags = 0;
-    D3D10_SUBRESOURCE_DATA InitData;
+
+    D3D10_SUBRESOURCE_DATA InitData = {};
     InitData.pSysMem = vertices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pVertexBuffer );
     if( FAILED( hr ) )
         return hr;
-
-    // Set vertex buffer
-    UINT stride = sizeof( SimpleVertex );
-    UINT offset = 0;
-    g_pd3dDevice->IASetVertexBuffers( 0, 1, &g_pVertexBuffer, &stride, &offset );
-
-    // Set primitive topology
-    g_pd3dDevice->IASetPrimitiveTopology( D3D10_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 
     return S_OK;
 }
@@ -318,7 +303,18 @@ void Render()
     float ClearColor[4] = { 0.0f, 0.125f, 0.3f, 1.0f }; // red,green,blue,alpha
     g_pd3dDevice->ClearRenderTargetView( g_pRenderTargetView, ClearColor );
 
-    // Render a triangle
+    // Set the input layout
+    g_pd3dDevice->IASetInputLayout(g_pVertexLayout);
+
+    // Set vertex buffer
+    UINT stride = sizeof(SimpleVertex);
+    UINT offset = 0;
+    g_pd3dDevice->IASetVertexBuffers(0, 1, &g_pVertexBuffer, &stride, &offset);
+
+    // Set primitive topology
+    g_pd3dDevice->IASetPrimitiveTopology(D3D10_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+    // Apply state and draw
     D3D10_TECHNIQUE_DESC techDesc;
     g_pTechnique->GetDesc( &techDesc );
     for( UINT p = 0; p < techDesc.Passes; ++p )

--- a/C++/Direct3D10/Tutorials/Tutorial03/Tutorial03.cpp
+++ b/C++/Direct3D10/Tutorials/Tutorial03/Tutorial03.cpp
@@ -24,16 +24,16 @@ struct SimpleVertex
 //--------------------------------------------------------------------------------------
 // Global Variables
 //--------------------------------------------------------------------------------------
-HINSTANCE               g_hInst = NULL;
-HWND                    g_hWnd = NULL;
+HINSTANCE               g_hInst = nullptr;
+HWND                    g_hWnd = nullptr;
 D3D10_DRIVER_TYPE       g_driverType = D3D10_DRIVER_TYPE_NULL;
-ID3D10Device*           g_pd3dDevice = NULL;
-IDXGISwapChain*         g_pSwapChain = NULL;
-ID3D10RenderTargetView* g_pRenderTargetView = NULL;
-ID3D10Effect*           g_pEffect = NULL;
-ID3D10EffectTechnique*  g_pTechnique = NULL;
-ID3D10InputLayout*      g_pVertexLayout = NULL;
-ID3D10Buffer*           g_pVertexBuffer = NULL;
+ID3D10Device*           g_pd3dDevice = nullptr;
+IDXGISwapChain*         g_pSwapChain = nullptr;
+ID3D10RenderTargetView* g_pRenderTargetView = nullptr;
+ID3D10Effect*           g_pEffect = nullptr;
+ID3D10EffectTechnique*  g_pTechnique = nullptr;
+ID3D10InputLayout*      g_pVertexLayout = nullptr;
+ID3D10Buffer*           g_pVertexBuffer = nullptr;
 
 
 //--------------------------------------------------------------------------------------
@@ -65,10 +65,10 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
     }
 
     // Main message loop
-    MSG msg = {0};
+    MSG msg = {};
     while( WM_QUIT != msg.message )
     {
-        if( PeekMessage( &msg, NULL, 0, 0, PM_REMOVE ) )
+        if( PeekMessage( &msg, nullptr, 0, 0, PM_REMOVE ) )
         {
             TranslateMessage( &msg );
             DispatchMessage( &msg );
@@ -81,7 +81,7 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
 
     CleanupDevice();
 
-    return ( int )msg.wParam;
+    return static_cast<int>(msg.wParam);
 }
 
 
@@ -91,17 +91,15 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
 HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
 {
     // Register class
-    WNDCLASSEX wcex;
+    WNDCLASSEX wcex = {};
     wcex.cbSize = sizeof( WNDCLASSEX );
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon( hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
-    wcex.hCursor = LoadCursor( NULL, IDC_ARROW );
+    wcex.hCursor = LoadCursor( nullptr, IDC_ARROW );
     wcex.hbrBackground = ( HBRUSH )( COLOR_WINDOW + 1 );
-    wcex.lpszMenuName = NULL;
+    wcex.lpszMenuName = nullptr;
     wcex.lpszClassName = L"TutorialWindowClass";
     wcex.hIconSm = LoadIcon( wcex.hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
     if( !RegisterClassEx( &wcex ) )
@@ -113,8 +111,8 @@ HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
     AdjustWindowRect( &rc, WS_OVERLAPPEDWINDOW, FALSE );
     g_hWnd = CreateWindow( L"TutorialWindowClass", L"Direct3D 10 Tutorial 3: Shaders and Effect System",
                            WS_OVERLAPPEDWINDOW,
-                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, NULL, NULL, hInstance,
-                           NULL );
+                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, nullptr, nullptr, hInstance,
+                           nullptr );
     if( !g_hWnd )
         return E_FAIL;
 
@@ -148,8 +146,7 @@ HRESULT InitDevice()
     };
     UINT numDriverTypes = sizeof( driverTypes ) / sizeof( driverTypes[0] );
 
-    DXGI_SWAP_CHAIN_DESC sd;
-    ZeroMemory( &sd, sizeof( sd ) );
+    DXGI_SWAP_CHAIN_DESC sd = {};
     sd.BufferCount = 1;
     sd.BufferDesc.Width = width;
     sd.BufferDesc.Height = height;
@@ -165,7 +162,7 @@ HRESULT InitDevice()
     for( UINT driverTypeIndex = 0; driverTypeIndex < numDriverTypes; driverTypeIndex++ )
     {
         g_driverType = driverTypes[driverTypeIndex];
-        hr = D3D10CreateDeviceAndSwapChain( NULL, g_driverType, NULL, createDeviceFlags,
+        hr = D3D10CreateDeviceAndSwapChain( nullptr, g_driverType, nullptr, createDeviceFlags,
                                             D3D10_SDK_VERSION, &sd, &g_pSwapChain, &g_pd3dDevice );
         if( SUCCEEDED( hr ) )
             break;
@@ -179,12 +176,12 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    hr = g_pd3dDevice->CreateRenderTargetView( pBuffer, NULL, &g_pRenderTargetView );
+    hr = g_pd3dDevice->CreateRenderTargetView( pBuffer, nullptr, &g_pRenderTargetView );
     pBuffer->Release();
     if( FAILED( hr ) )
         return hr;
 
-    g_pd3dDevice->OMSetRenderTargets( 1, &g_pRenderTargetView, NULL );
+    g_pd3dDevice->OMSetRenderTargets( 1, &g_pRenderTargetView, nullptr );
 
     // Setup the viewport
     D3D10_VIEWPORT vp;
@@ -205,11 +202,11 @@ HRESULT InitDevice()
     // the release configuration of this program.
     dwShaderFlags |= D3D10_SHADER_DEBUG;
     #endif
-    hr = D3DX10CreateEffectFromFile( L"Tutorial03.fx", NULL, NULL, "fx_4_0", dwShaderFlags, 0,
-                                         g_pd3dDevice, NULL, NULL, &g_pEffect, NULL, NULL );
+    hr = D3DX10CreateEffectFromFile( L"Tutorial03.fx", nullptr, nullptr, "fx_4_0", dwShaderFlags, 0,
+                                         g_pd3dDevice, nullptr, nullptr, &g_pEffect, nullptr, nullptr );
     if( FAILED( hr ) )
     {
-        MessageBox( NULL,
+        MessageBox( nullptr,
                     L"The FX file cannot be located.  Please run this executable from the directory that contains the FX file.", L"Error", MB_OK );
         return hr;
     }
@@ -218,7 +215,7 @@ HRESULT InitDevice()
     g_pTechnique = g_pEffect->GetTechniqueByName( "Render" );
 
     // Define the input layout
-    D3D10_INPUT_ELEMENT_DESC layout[] =
+    const D3D10_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D10_INPUT_PER_VERTEX_DATA, 0 },
     };
@@ -232,35 +229,23 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    // Set the input layout
-    g_pd3dDevice->IASetInputLayout( g_pVertexLayout );
-
     // Create vertex buffer
-    SimpleVertex vertices[] =
+    const SimpleVertex vertices[] =
     {
         D3DXVECTOR3( 0.0f, 0.5f, 0.5f ),
         D3DXVECTOR3( 0.5f, -0.5f, 0.5f ),
         D3DXVECTOR3( -0.5f, -0.5f, 0.5f ),
     };
-    D3D10_BUFFER_DESC bd;
+    D3D10_BUFFER_DESC bd = {};
     bd.Usage = D3D10_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( SimpleVertex ) * 3;
     bd.BindFlags = D3D10_BIND_VERTEX_BUFFER;
-    bd.CPUAccessFlags = 0;
-    bd.MiscFlags = 0;
-    D3D10_SUBRESOURCE_DATA InitData;
+
+    D3D10_SUBRESOURCE_DATA InitData = {};
     InitData.pSysMem = vertices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pVertexBuffer );
     if( FAILED( hr ) )
         return hr;
-
-    // Set vertex buffer
-    UINT stride = sizeof( SimpleVertex );
-    UINT offset = 0;
-    g_pd3dDevice->IASetVertexBuffers( 0, 1, &g_pVertexBuffer, &stride, &offset );
-
-    // Set primitive topology
-    g_pd3dDevice->IASetPrimitiveTopology( D3D10_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 
     return S_OK;
 }
@@ -318,7 +303,18 @@ void Render()
     float ClearColor[4] = { 0.0f, 0.125f, 0.3f, 1.0f }; // red,green,blue,alpha
     g_pd3dDevice->ClearRenderTargetView( g_pRenderTargetView, ClearColor );
 
-    // Render a triangle
+    // Set the input layout
+    g_pd3dDevice->IASetInputLayout(g_pVertexLayout);
+
+    // Set vertex buffer
+    UINT stride = sizeof(SimpleVertex);
+    UINT offset = 0;
+    g_pd3dDevice->IASetVertexBuffers(0, 1, &g_pVertexBuffer, &stride, &offset);
+
+    // Set primitive topology
+    g_pd3dDevice->IASetPrimitiveTopology(D3D10_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+    // Apply state and draw
     D3D10_TECHNIQUE_DESC techDesc;
     g_pTechnique->GetDesc( &techDesc );
     for( UINT p = 0; p < techDesc.Passes; ++p )

--- a/C++/Direct3D10/Tutorials/Tutorial04/Tutorial04.cpp
+++ b/C++/Direct3D10/Tutorials/Tutorial04/Tutorial04.cpp
@@ -25,20 +25,20 @@ struct SimpleVertex
 //--------------------------------------------------------------------------------------
 // Global Variables
 //--------------------------------------------------------------------------------------
-HINSTANCE                   g_hInst = NULL;
-HWND                        g_hWnd = NULL;
+HINSTANCE                   g_hInst = nullptr;
+HWND                        g_hWnd = nullptr;
 D3D10_DRIVER_TYPE           g_driverType = D3D10_DRIVER_TYPE_NULL;
-ID3D10Device*               g_pd3dDevice = NULL;
-IDXGISwapChain*             g_pSwapChain = NULL;
-ID3D10RenderTargetView*     g_pRenderTargetView = NULL;
-ID3D10Effect*               g_pEffect = NULL;
-ID3D10EffectTechnique*      g_pTechnique = NULL;
-ID3D10InputLayout*          g_pVertexLayout = NULL;
-ID3D10Buffer*               g_pVertexBuffer = NULL;
-ID3D10Buffer*               g_pIndexBuffer = NULL;
-ID3D10EffectMatrixVariable* g_pWorldVariable = NULL;
-ID3D10EffectMatrixVariable* g_pViewVariable = NULL;
-ID3D10EffectMatrixVariable* g_pProjectionVariable = NULL;
+ID3D10Device*               g_pd3dDevice = nullptr;
+IDXGISwapChain*             g_pSwapChain = nullptr;
+ID3D10RenderTargetView*     g_pRenderTargetView = nullptr;
+ID3D10Effect*               g_pEffect = nullptr;
+ID3D10EffectTechnique*      g_pTechnique = nullptr;
+ID3D10InputLayout*          g_pVertexLayout = nullptr;
+ID3D10Buffer*               g_pVertexBuffer = nullptr;
+ID3D10Buffer*               g_pIndexBuffer = nullptr;
+ID3D10EffectMatrixVariable* g_pWorldVariable = nullptr;
+ID3D10EffectMatrixVariable* g_pViewVariable = nullptr;
+ID3D10EffectMatrixVariable* g_pProjectionVariable = nullptr;
 D3DXMATRIX                  g_World;
 D3DXMATRIX                  g_View;
 D3DXMATRIX                  g_Projection;
@@ -73,10 +73,10 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
     }
 
     // Main message loop
-    MSG msg = {0};
+    MSG msg = {};
     while( WM_QUIT != msg.message )
     {
-        if( PeekMessage( &msg, NULL, 0, 0, PM_REMOVE ) )
+        if( PeekMessage( &msg, nullptr, 0, 0, PM_REMOVE ) )
         {
             TranslateMessage( &msg );
             DispatchMessage( &msg );
@@ -89,7 +89,7 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
 
     CleanupDevice();
 
-    return ( int )msg.wParam;
+    return static_cast<int>(msg.wParam);
 }
 
 
@@ -99,17 +99,15 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
 HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
 {
     // Register class
-    WNDCLASSEX wcex;
+    WNDCLASSEX wcex = {};
     wcex.cbSize = sizeof( WNDCLASSEX );
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon( hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
-    wcex.hCursor = LoadCursor( NULL, IDC_ARROW );
+    wcex.hCursor = LoadCursor( nullptr, IDC_ARROW );
     wcex.hbrBackground = ( HBRUSH )( COLOR_WINDOW + 1 );
-    wcex.lpszMenuName = NULL;
+    wcex.lpszMenuName = nullptr;
     wcex.lpszClassName = L"TutorialWindowClass";
     wcex.hIconSm = LoadIcon( wcex.hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
     if( !RegisterClassEx( &wcex ) )
@@ -120,8 +118,8 @@ HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
     RECT rc = { 0, 0, 640, 480 };
     AdjustWindowRect( &rc, WS_OVERLAPPEDWINDOW, FALSE );
     g_hWnd = CreateWindow( L"TutorialWindowClass", L"Direct3D 10 Tutorial 4: 3D Spaces", WS_OVERLAPPEDWINDOW,
-                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, NULL, NULL, hInstance,
-                           NULL );
+                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, nullptr, nullptr, hInstance,
+                           nullptr );
     if( !g_hWnd )
         return E_FAIL;
 
@@ -155,8 +153,7 @@ HRESULT InitDevice()
     };
     UINT numDriverTypes = sizeof( driverTypes ) / sizeof( driverTypes[0] );
 
-    DXGI_SWAP_CHAIN_DESC sd;
-    ZeroMemory( &sd, sizeof( sd ) );
+    DXGI_SWAP_CHAIN_DESC sd = {};
     sd.BufferCount = 1;
     sd.BufferDesc.Width = width;
     sd.BufferDesc.Height = height;
@@ -172,7 +169,7 @@ HRESULT InitDevice()
     for( UINT driverTypeIndex = 0; driverTypeIndex < numDriverTypes; driverTypeIndex++ )
     {
         g_driverType = driverTypes[driverTypeIndex];
-        hr = D3D10CreateDeviceAndSwapChain( NULL, g_driverType, NULL, createDeviceFlags,
+        hr = D3D10CreateDeviceAndSwapChain( nullptr, g_driverType, nullptr, createDeviceFlags,
                                             D3D10_SDK_VERSION, &sd, &g_pSwapChain, &g_pd3dDevice );
         if( SUCCEEDED( hr ) )
             break;
@@ -186,12 +183,12 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    hr = g_pd3dDevice->CreateRenderTargetView( pBuffer, NULL, &g_pRenderTargetView );
+    hr = g_pd3dDevice->CreateRenderTargetView( pBuffer, nullptr, &g_pRenderTargetView );
     pBuffer->Release();
     if( FAILED( hr ) )
         return hr;
 
-    g_pd3dDevice->OMSetRenderTargets( 1, &g_pRenderTargetView, NULL );
+    g_pd3dDevice->OMSetRenderTargets( 1, &g_pRenderTargetView, nullptr );
 
     // Setup the viewport
     D3D10_VIEWPORT vp;
@@ -212,11 +209,11 @@ HRESULT InitDevice()
     // the release configuration of this program.
     dwShaderFlags |= D3D10_SHADER_DEBUG;
     #endif
-    hr = D3DX10CreateEffectFromFile( L"Tutorial04.fx", NULL, NULL, "fx_4_0", dwShaderFlags, 0, g_pd3dDevice, NULL,
-                                         NULL, &g_pEffect, NULL, NULL );
+    hr = D3DX10CreateEffectFromFile( L"Tutorial04.fx", nullptr, nullptr, "fx_4_0", dwShaderFlags, 0, g_pd3dDevice, nullptr,
+                                         nullptr, &g_pEffect, nullptr, nullptr );
     if( FAILED( hr ) )
     {
-        MessageBox( NULL,
+        MessageBox( nullptr,
                     L"The FX file cannot be located.  Please run this executable from the directory that contains the FX file.", L"Error", MB_OK );
         return hr;
     }
@@ -230,7 +227,7 @@ HRESULT InitDevice()
     g_pProjectionVariable = g_pEffect->GetVariableByName( "Projection" )->AsMatrix();
 
     // Define the input layout
-    D3D10_INPUT_ELEMENT_DESC layout[] =
+    const D3D10_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D10_INPUT_PER_VERTEX_DATA, 0 },
         { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D10_INPUT_PER_VERTEX_DATA, 0 },
@@ -245,11 +242,8 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    // Set the input layout
-    g_pd3dDevice->IASetInputLayout( g_pVertexLayout );
-
     // Create vertex buffer
-    SimpleVertex vertices[] =
+    const SimpleVertex vertices[] =
     {
         { D3DXVECTOR3( -1.0f, 1.0f, -1.0f ), D3DXVECTOR4( 0.0f, 0.0f, 1.0f, 1.0f ) },
         { D3DXVECTOR3( 1.0f, 1.0f, -1.0f ), D3DXVECTOR4( 0.0f, 1.0f, 0.0f, 1.0f ) },
@@ -260,25 +254,19 @@ HRESULT InitDevice()
         { D3DXVECTOR3( 1.0f, -1.0f, 1.0f ), D3DXVECTOR4( 1.0f, 1.0f, 1.0f, 1.0f ) },
         { D3DXVECTOR3( -1.0f, -1.0f, 1.0f ), D3DXVECTOR4( 0.0f, 0.0f, 0.0f, 1.0f ) },
     };
-    D3D10_BUFFER_DESC bd;
+    D3D10_BUFFER_DESC bd = {};
     bd.Usage = D3D10_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( SimpleVertex ) * 8;
     bd.BindFlags = D3D10_BIND_VERTEX_BUFFER;
-    bd.CPUAccessFlags = 0;
-    bd.MiscFlags = 0;
-    D3D10_SUBRESOURCE_DATA InitData;
+
+    D3D10_SUBRESOURCE_DATA InitData = {};
     InitData.pSysMem = vertices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pVertexBuffer );
     if( FAILED( hr ) )
         return hr;
 
-    // Set vertex buffer
-    UINT stride = sizeof( SimpleVertex );
-    UINT offset = 0;
-    g_pd3dDevice->IASetVertexBuffers( 0, 1, &g_pVertexBuffer, &stride, &offset );
-
     // Create index buffer
-    DWORD indices[] =
+    const DWORD indices[] =
     {
         3,1,0,
         2,1,3,
@@ -301,18 +289,10 @@ HRESULT InitDevice()
     bd.Usage = D3D10_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( DWORD ) * 36;        // 36 vertices needed for 12 triangles in a triangle list
     bd.BindFlags = D3D10_BIND_INDEX_BUFFER;
-    bd.CPUAccessFlags = 0;
-    bd.MiscFlags = 0;
     InitData.pSysMem = indices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pIndexBuffer );
     if( FAILED( hr ) )
         return hr;
-
-    // Set index buffer
-    g_pd3dDevice->IASetIndexBuffer( g_pIndexBuffer, DXGI_FORMAT_R32_UINT, 0 );
-
-    // Set primitive topology
-    g_pd3dDevice->IASetPrimitiveTopology( D3D10_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 
     // Initialize the world matrix
     D3DXMatrixIdentity( &g_World );
@@ -415,6 +395,22 @@ void Render()
     //
     // Renders a triangle
     //
+
+    // Set the input layout
+    g_pd3dDevice->IASetInputLayout(g_pVertexLayout);
+
+    // Set vertex buffer
+    UINT stride = sizeof(SimpleVertex);
+    UINT offset = 0;
+    g_pd3dDevice->IASetVertexBuffers(0, 1, &g_pVertexBuffer, &stride, &offset);
+
+    // Set index buffer
+    g_pd3dDevice->IASetIndexBuffer(g_pIndexBuffer, DXGI_FORMAT_R32_UINT, 0);
+
+    // Set primitive topology
+    g_pd3dDevice->IASetPrimitiveTopology(D3D10_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+    // Apply state and draw
     D3D10_TECHNIQUE_DESC techDesc;
     g_pTechnique->GetDesc( &techDesc );
     for( UINT p = 0; p < techDesc.Passes; ++p )

--- a/C++/Direct3D10/Tutorials/Tutorial05/Tutorial05.cpp
+++ b/C++/Direct3D10/Tutorials/Tutorial05/Tutorial05.cpp
@@ -25,22 +25,22 @@ struct SimpleVertex
 //--------------------------------------------------------------------------------------
 // Global Variables
 //--------------------------------------------------------------------------------------
-HINSTANCE                   g_hInst = NULL;
-HWND                        g_hWnd = NULL;
+HINSTANCE                   g_hInst = nullptr;
+HWND                        g_hWnd = nullptr;
 D3D10_DRIVER_TYPE           g_driverType = D3D10_DRIVER_TYPE_NULL;
-ID3D10Device*               g_pd3dDevice = NULL;
-IDXGISwapChain*             g_pSwapChain = NULL;
-ID3D10RenderTargetView*     g_pRenderTargetView = NULL;
-ID3D10Texture2D*            g_pDepthStencil = NULL;
-ID3D10DepthStencilView*     g_pDepthStencilView = NULL;
-ID3D10Effect*               g_pEffect = NULL;
-ID3D10EffectTechnique*      g_pTechnique = NULL;
-ID3D10InputLayout*          g_pVertexLayout = NULL;
-ID3D10Buffer*               g_pVertexBuffer = NULL;
-ID3D10Buffer*               g_pIndexBuffer = NULL;
-ID3D10EffectMatrixVariable* g_pWorldVariable = NULL;
-ID3D10EffectMatrixVariable* g_pViewVariable = NULL;
-ID3D10EffectMatrixVariable* g_pProjectionVariable = NULL;
+ID3D10Device*               g_pd3dDevice = nullptr;
+IDXGISwapChain*             g_pSwapChain = nullptr;
+ID3D10RenderTargetView*     g_pRenderTargetView = nullptr;
+ID3D10Texture2D*            g_pDepthStencil = nullptr;
+ID3D10DepthStencilView*     g_pDepthStencilView = nullptr;
+ID3D10Effect*               g_pEffect = nullptr;
+ID3D10EffectTechnique*      g_pTechnique = nullptr;
+ID3D10InputLayout*          g_pVertexLayout = nullptr;
+ID3D10Buffer*               g_pVertexBuffer = nullptr;
+ID3D10Buffer*               g_pIndexBuffer = nullptr;
+ID3D10EffectMatrixVariable* g_pWorldVariable = nullptr;
+ID3D10EffectMatrixVariable* g_pViewVariable = nullptr;
+ID3D10EffectMatrixVariable* g_pProjectionVariable = nullptr;
 D3DXMATRIX                  g_World1;
 D3DXMATRIX                  g_World2;
 D3DXMATRIX                  g_View;
@@ -76,10 +76,10 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
     }
 
     // Main message loop
-    MSG msg = {0};
+    MSG msg = {};
     while( WM_QUIT != msg.message )
     {
-        if( PeekMessage( &msg, NULL, 0, 0, PM_REMOVE ) )
+        if( PeekMessage( &msg, nullptr, 0, 0, PM_REMOVE ) )
         {
             TranslateMessage( &msg );
             DispatchMessage( &msg );
@@ -92,7 +92,7 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
 
     CleanupDevice();
 
-    return ( int )msg.wParam;
+    return static_cast<int>(msg.wParam);
 }
 
 
@@ -102,17 +102,15 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
 HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
 {
     // Register class
-    WNDCLASSEX wcex;
+    WNDCLASSEX wcex = {};
     wcex.cbSize = sizeof( WNDCLASSEX );
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon( hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
-    wcex.hCursor = LoadCursor( NULL, IDC_ARROW );
+    wcex.hCursor = LoadCursor( nullptr, IDC_ARROW );
     wcex.hbrBackground = ( HBRUSH )( COLOR_WINDOW + 1 );
-    wcex.lpszMenuName = NULL;
+    wcex.lpszMenuName = nullptr;
     wcex.lpszClassName = L"TutorialWindowClass";
     wcex.hIconSm = LoadIcon( wcex.hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
     if( !RegisterClassEx( &wcex ) )
@@ -123,8 +121,8 @@ HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
     RECT rc = { 0, 0, 640, 480 };
     AdjustWindowRect( &rc, WS_OVERLAPPEDWINDOW, FALSE );
     g_hWnd = CreateWindow( L"TutorialWindowClass", L"Direct3D 10 Tutorial 5", WS_OVERLAPPEDWINDOW,
-                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, NULL, NULL, hInstance,
-                           NULL );
+                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, nullptr, nullptr, hInstance,
+                           nullptr );
     if( !g_hWnd )
         return E_FAIL;
 
@@ -158,8 +156,7 @@ HRESULT InitDevice()
     };
     UINT numDriverTypes = sizeof( driverTypes ) / sizeof( driverTypes[0] );
 
-    DXGI_SWAP_CHAIN_DESC sd;
-    ZeroMemory( &sd, sizeof( sd ) );
+    DXGI_SWAP_CHAIN_DESC sd = {};
     sd.BufferCount = 1;
     sd.BufferDesc.Width = width;
     sd.BufferDesc.Height = height;
@@ -175,7 +172,7 @@ HRESULT InitDevice()
     for( UINT driverTypeIndex = 0; driverTypeIndex < numDriverTypes; driverTypeIndex++ )
     {
         g_driverType = driverTypes[driverTypeIndex];
-        hr = D3D10CreateDeviceAndSwapChain( NULL, g_driverType, NULL, createDeviceFlags,
+        hr = D3D10CreateDeviceAndSwapChain( nullptr, g_driverType, nullptr, createDeviceFlags,
                                             D3D10_SDK_VERSION, &sd, &g_pSwapChain, &g_pd3dDevice );
         if( SUCCEEDED( hr ) )
             break;
@@ -189,7 +186,7 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    hr = g_pd3dDevice->CreateRenderTargetView( pBuffer, NULL, &g_pRenderTargetView );
+    hr = g_pd3dDevice->CreateRenderTargetView( pBuffer, nullptr, &g_pRenderTargetView );
     pBuffer->Release();
     if( FAILED( hr ) )
         return hr;
@@ -207,7 +204,7 @@ HRESULT InitDevice()
     descDepth.BindFlags = D3D10_BIND_DEPTH_STENCIL;
     descDepth.CPUAccessFlags = 0;
     descDepth.MiscFlags = 0;
-    hr = g_pd3dDevice->CreateTexture2D( &descDepth, NULL, &g_pDepthStencil );
+    hr = g_pd3dDevice->CreateTexture2D( &descDepth, nullptr, &g_pDepthStencil );
     if( FAILED( hr ) )
         return hr;
 
@@ -241,11 +238,11 @@ HRESULT InitDevice()
     // the release configuration of this program.
     dwShaderFlags |= D3D10_SHADER_DEBUG;
     #endif
-    hr = D3DX10CreateEffectFromFile( L"Tutorial05.fx", NULL, NULL, "fx_4_0", dwShaderFlags, 0, g_pd3dDevice, NULL,
-                                         NULL, &g_pEffect, NULL, NULL );
+    hr = D3DX10CreateEffectFromFile( L"Tutorial05.fx", nullptr, nullptr, "fx_4_0", dwShaderFlags, 0, g_pd3dDevice, nullptr,
+                                         nullptr, &g_pEffect, nullptr, nullptr );
     if( FAILED( hr ) )
     {
-        MessageBox( NULL,
+        MessageBox( nullptr,
                     L"The FX file cannot be located.  Please run this executable from the directory that contains the FX file.", L"Error", MB_OK );
         return hr;
     }
@@ -259,7 +256,7 @@ HRESULT InitDevice()
     g_pProjectionVariable = g_pEffect->GetVariableByName( "Projection" )->AsMatrix();
 
     // Define the input layout
-    D3D10_INPUT_ELEMENT_DESC layout[] =
+    const D3D10_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D10_INPUT_PER_VERTEX_DATA, 0 },
         { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D10_INPUT_PER_VERTEX_DATA, 0 },
@@ -274,11 +271,8 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    // Set the input layout
-    g_pd3dDevice->IASetInputLayout( g_pVertexLayout );
-
     // Create vertex buffer
-    SimpleVertex vertices[] =
+    const SimpleVertex vertices[] =
     {
         { D3DXVECTOR3( -1.0f, 1.0f, -1.0f ), D3DXVECTOR4( 0.0f, 0.0f, 1.0f, 1.0f ) },
         { D3DXVECTOR3( 1.0f, 1.0f, -1.0f ), D3DXVECTOR4( 0.0f, 1.0f, 0.0f, 1.0f ) },
@@ -289,26 +283,19 @@ HRESULT InitDevice()
         { D3DXVECTOR3( 1.0f, -1.0f, 1.0f ), D3DXVECTOR4( 1.0f, 1.0f, 1.0f, 1.0f ) },
         { D3DXVECTOR3( -1.0f, -1.0f, 1.0f ), D3DXVECTOR4( 0.0f, 0.0f, 0.0f, 1.0f ) },
     };
-    D3D10_BUFFER_DESC bd;
+    D3D10_BUFFER_DESC bd = {};
     bd.Usage = D3D10_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( SimpleVertex ) * 8;
     bd.BindFlags = D3D10_BIND_VERTEX_BUFFER;
-    bd.CPUAccessFlags = 0;
-    bd.MiscFlags = 0;
-    D3D10_SUBRESOURCE_DATA InitData;
+
+    D3D10_SUBRESOURCE_DATA InitData = {};
     InitData.pSysMem = vertices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pVertexBuffer );
     if( FAILED( hr ) )
         return hr;
 
-    // Set vertex buffer
-    UINT stride = sizeof( SimpleVertex );
-    UINT offset = 0;
-    g_pd3dDevice->IASetVertexBuffers( 0, 1, &g_pVertexBuffer, &stride, &offset );
-
     // Create index buffer
-    // Create vertex buffer
-    DWORD indices[] =
+    const DWORD indices[] =
     {
         3,1,0,
         2,1,3,
@@ -331,18 +318,10 @@ HRESULT InitDevice()
     bd.Usage = D3D10_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( DWORD ) * 36;
     bd.BindFlags = D3D10_BIND_INDEX_BUFFER;
-    bd.CPUAccessFlags = 0;
-    bd.MiscFlags = 0;
     InitData.pSysMem = indices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pIndexBuffer );
     if( FAILED( hr ) )
         return hr;
-
-    // Set index buffer
-    g_pd3dDevice->IASetIndexBuffer( g_pIndexBuffer, DXGI_FORMAT_R32_UINT, 0 );
-
-    // Set primitive topology
-    g_pd3dDevice->IASetPrimitiveTopology( D3D10_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 
     // Initialize the world matrices
     D3DXMatrixIdentity( &g_World1 );
@@ -461,6 +440,20 @@ void Render()
     g_pWorldVariable->SetMatrix( ( float* )&g_World1 );
     g_pViewVariable->SetMatrix( ( float* )&g_View );
     g_pProjectionVariable->SetMatrix( ( float* )&g_Projection );
+
+    // Set the input layout
+    g_pd3dDevice->IASetInputLayout(g_pVertexLayout);
+
+    // Set vertex buffer
+    UINT stride = sizeof(SimpleVertex);
+    UINT offset = 0;
+    g_pd3dDevice->IASetVertexBuffers(0, 1, &g_pVertexBuffer, &stride, &offset);
+
+    // Set index buffer
+    g_pd3dDevice->IASetIndexBuffer(g_pIndexBuffer, DXGI_FORMAT_R32_UINT, 0);
+
+    // Set primitive topology
+    g_pd3dDevice->IASetPrimitiveTopology(D3D10_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
     //
     // Render the first cube

--- a/C++/Direct3D10/Tutorials/Tutorial06/Tutorial06.cpp
+++ b/C++/Direct3D10/Tutorials/Tutorial06/Tutorial06.cpp
@@ -25,26 +25,26 @@ struct SimpleVertex
 //--------------------------------------------------------------------------------------
 // Global Variables
 //--------------------------------------------------------------------------------------
-HINSTANCE                   g_hInst = NULL;
-HWND                        g_hWnd = NULL;
+HINSTANCE                   g_hInst = nullptr;
+HWND                        g_hWnd = nullptr;
 D3D10_DRIVER_TYPE           g_driverType = D3D10_DRIVER_TYPE_NULL;
-ID3D10Device*               g_pd3dDevice = NULL;
-IDXGISwapChain*             g_pSwapChain = NULL;
-ID3D10RenderTargetView*     g_pRenderTargetView = NULL;
-ID3D10Texture2D*            g_pDepthStencil = NULL;
-ID3D10DepthStencilView*     g_pDepthStencilView = NULL;
-ID3D10Effect*               g_pEffect = NULL;
-ID3D10EffectTechnique*      g_pTechniqueRender = NULL;
-ID3D10EffectTechnique*      g_pTechniqueRenderLight = NULL;
-ID3D10InputLayout*          g_pVertexLayout = NULL;
-ID3D10Buffer*               g_pVertexBuffer = NULL;
-ID3D10Buffer*               g_pIndexBuffer = NULL;
-ID3D10EffectMatrixVariable* g_pWorldVariable = NULL;
-ID3D10EffectMatrixVariable* g_pViewVariable = NULL;
-ID3D10EffectMatrixVariable* g_pProjectionVariable = NULL;
-ID3D10EffectVectorVariable* g_pLightDirVariable = NULL;
-ID3D10EffectVectorVariable* g_pLightColorVariable = NULL;
-ID3D10EffectVectorVariable* g_pOutputColorVariable = NULL;
+ID3D10Device*               g_pd3dDevice = nullptr;
+IDXGISwapChain*             g_pSwapChain = nullptr;
+ID3D10RenderTargetView*     g_pRenderTargetView = nullptr;
+ID3D10Texture2D*            g_pDepthStencil = nullptr;
+ID3D10DepthStencilView*     g_pDepthStencilView = nullptr;
+ID3D10Effect*               g_pEffect = nullptr;
+ID3D10EffectTechnique*      g_pTechniqueRender = nullptr;
+ID3D10EffectTechnique*      g_pTechniqueRenderLight = nullptr;
+ID3D10InputLayout*          g_pVertexLayout = nullptr;
+ID3D10Buffer*               g_pVertexBuffer = nullptr;
+ID3D10Buffer*               g_pIndexBuffer = nullptr;
+ID3D10EffectMatrixVariable* g_pWorldVariable = nullptr;
+ID3D10EffectMatrixVariable* g_pViewVariable = nullptr;
+ID3D10EffectMatrixVariable* g_pProjectionVariable = nullptr;
+ID3D10EffectVectorVariable* g_pLightDirVariable = nullptr;
+ID3D10EffectVectorVariable* g_pLightColorVariable = nullptr;
+ID3D10EffectVectorVariable* g_pOutputColorVariable = nullptr;
 D3DXMATRIX                  g_World;
 D3DXMATRIX                  g_View;
 D3DXMATRIX                  g_Projection;
@@ -79,10 +79,10 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
     }
 
     // Main message loop
-    MSG msg = {0};
+    MSG msg = {};
     while( WM_QUIT != msg.message )
     {
-        if( PeekMessage( &msg, NULL, 0, 0, PM_REMOVE ) )
+        if( PeekMessage( &msg, nullptr, 0, 0, PM_REMOVE ) )
         {
             TranslateMessage( &msg );
             DispatchMessage( &msg );
@@ -95,7 +95,7 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
 
     CleanupDevice();
 
-    return ( int )msg.wParam;
+    return static_cast<int>(msg.wParam);
 }
 
 
@@ -105,17 +105,15 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
 HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
 {
     // Register class
-    WNDCLASSEX wcex;
+    WNDCLASSEX wcex = {};
     wcex.cbSize = sizeof( WNDCLASSEX );
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon( hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
-    wcex.hCursor = LoadCursor( NULL, IDC_ARROW );
+    wcex.hCursor = LoadCursor( nullptr, IDC_ARROW );
     wcex.hbrBackground = ( HBRUSH )( COLOR_WINDOW + 1 );
-    wcex.lpszMenuName = NULL;
+    wcex.lpszMenuName = nullptr;
     wcex.lpszClassName = L"TutorialWindowClass";
     wcex.hIconSm = LoadIcon( wcex.hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
     if( !RegisterClassEx( &wcex ) )
@@ -126,8 +124,8 @@ HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
     RECT rc = { 0, 0, 640, 480 };
     AdjustWindowRect( &rc, WS_OVERLAPPEDWINDOW, FALSE );
     g_hWnd = CreateWindow( L"TutorialWindowClass", L"Direct3D 10 Tutorial 6", WS_OVERLAPPEDWINDOW,
-                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, NULL, NULL, hInstance,
-                           NULL );
+                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, nullptr, nullptr, hInstance,
+                           nullptr );
     if( !g_hWnd )
         return E_FAIL;
 
@@ -161,8 +159,7 @@ HRESULT InitDevice()
     };
     UINT numDriverTypes = sizeof( driverTypes ) / sizeof( driverTypes[0] );
 
-    DXGI_SWAP_CHAIN_DESC sd;
-    ZeroMemory( &sd, sizeof( sd ) );
+    DXGI_SWAP_CHAIN_DESC sd = {};
     sd.BufferCount = 1;
     sd.BufferDesc.Width = width;
     sd.BufferDesc.Height = height;
@@ -178,7 +175,7 @@ HRESULT InitDevice()
     for( UINT driverTypeIndex = 0; driverTypeIndex < numDriverTypes; driverTypeIndex++ )
     {
         g_driverType = driverTypes[driverTypeIndex];
-        hr = D3D10CreateDeviceAndSwapChain( NULL, g_driverType, NULL, createDeviceFlags,
+        hr = D3D10CreateDeviceAndSwapChain( nullptr, g_driverType, nullptr, createDeviceFlags,
                                             D3D10_SDK_VERSION, &sd, &g_pSwapChain, &g_pd3dDevice );
         if( SUCCEEDED( hr ) )
             break;
@@ -192,7 +189,7 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    hr = g_pd3dDevice->CreateRenderTargetView( pBuffer, NULL, &g_pRenderTargetView );
+    hr = g_pd3dDevice->CreateRenderTargetView( pBuffer, nullptr, &g_pRenderTargetView );
     pBuffer->Release();
     if( FAILED( hr ) )
         return hr;
@@ -210,7 +207,7 @@ HRESULT InitDevice()
     descDepth.BindFlags = D3D10_BIND_DEPTH_STENCIL;
     descDepth.CPUAccessFlags = 0;
     descDepth.MiscFlags = 0;
-    hr = g_pd3dDevice->CreateTexture2D( &descDepth, NULL, &g_pDepthStencil );
+    hr = g_pd3dDevice->CreateTexture2D( &descDepth, nullptr, &g_pDepthStencil );
     if( FAILED( hr ) )
         return hr;
 
@@ -244,11 +241,11 @@ HRESULT InitDevice()
     // the release configuration of this program.
     dwShaderFlags |= D3D10_SHADER_DEBUG;
     #endif
-    hr = D3DX10CreateEffectFromFile( L"Tutorial06.fx", NULL, NULL, "fx_4_0", dwShaderFlags, 0, g_pd3dDevice, NULL,
-                                         NULL, &g_pEffect, NULL, NULL );
+    hr = D3DX10CreateEffectFromFile( L"Tutorial06.fx", nullptr, nullptr, "fx_4_0", dwShaderFlags, 0, g_pd3dDevice, nullptr,
+                                         nullptr, &g_pEffect, nullptr, nullptr );
     if( FAILED( hr ) )
     {
-        MessageBox( NULL,
+        MessageBox( nullptr,
                     L"The FX file cannot be located.  Please run this executable from the directory that contains the FX file.", L"Error", MB_OK );
         return hr;
     }
@@ -266,7 +263,7 @@ HRESULT InitDevice()
     g_pOutputColorVariable = g_pEffect->GetVariableByName( "vOutputColor" )->AsVector();
 
     // Define the input layout
-    D3D10_INPUT_ELEMENT_DESC layout[] =
+    const D3D10_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D10_INPUT_PER_VERTEX_DATA, 0 },
         { "NORMAL", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D10_INPUT_PER_VERTEX_DATA, 0 },
@@ -281,11 +278,8 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    // Set the input layout
-    g_pd3dDevice->IASetInputLayout( g_pVertexLayout );
-
     // Create vertex buffer
-    SimpleVertex vertices[] =
+    const SimpleVertex vertices[] =
     {
         { D3DXVECTOR3( -1.0f, 1.0f, -1.0f ), D3DXVECTOR3( 0.0f, 1.0f, 0.0f ) },
         { D3DXVECTOR3( 1.0f, 1.0f, -1.0f ), D3DXVECTOR3( 0.0f, 1.0f, 0.0f ) },
@@ -317,26 +311,19 @@ HRESULT InitDevice()
         { D3DXVECTOR3( 1.0f, 1.0f, 1.0f ), D3DXVECTOR3( 0.0f, 0.0f, 1.0f ) },
         { D3DXVECTOR3( -1.0f, 1.0f, 1.0f ), D3DXVECTOR3( 0.0f, 0.0f, 1.0f ) },
     };
-    D3D10_BUFFER_DESC bd;
+    D3D10_BUFFER_DESC bd = {};
     bd.Usage = D3D10_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( SimpleVertex ) * 24;
     bd.BindFlags = D3D10_BIND_VERTEX_BUFFER;
-    bd.CPUAccessFlags = 0;
-    bd.MiscFlags = 0;
-    D3D10_SUBRESOURCE_DATA InitData;
+
+    D3D10_SUBRESOURCE_DATA InitData = {};
     InitData.pSysMem = vertices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pVertexBuffer );
     if( FAILED( hr ) )
         return hr;
 
-    // Set vertex buffer
-    UINT stride = sizeof( SimpleVertex );
-    UINT offset = 0;
-    g_pd3dDevice->IASetVertexBuffers( 0, 1, &g_pVertexBuffer, &stride, &offset );
-
     // Create index buffer
-    // Create vertex buffer
-    DWORD indices[] =
+    const DWORD indices[] =
     {
         3,1,0,
         2,1,3,
@@ -359,18 +346,10 @@ HRESULT InitDevice()
     bd.Usage = D3D10_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( DWORD ) * 36;
     bd.BindFlags = D3D10_BIND_INDEX_BUFFER;
-    bd.CPUAccessFlags = 0;
-    bd.MiscFlags = 0;
     InitData.pSysMem = indices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pIndexBuffer );
     if( FAILED( hr ) )
         return hr;
-
-    // Set index buffer
-    g_pd3dDevice->IASetIndexBuffer( g_pIndexBuffer, DXGI_FORMAT_R32_UINT, 0 );
-
-    // Set primitive topology
-    g_pd3dDevice->IASetPrimitiveTopology( D3D10_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 
     // Initialize the world matrices
     D3DXMatrixIdentity( &g_World );
@@ -502,6 +481,22 @@ void Render()
     //
     // Render the cube
     //
+
+    // Set the input layout
+    g_pd3dDevice->IASetInputLayout(g_pVertexLayout);
+
+    // Set vertex buffer
+    UINT stride = sizeof(SimpleVertex);
+    UINT offset = 0;
+    g_pd3dDevice->IASetVertexBuffers(0, 1, &g_pVertexBuffer, &stride, &offset);
+
+    // Set index buffer
+    g_pd3dDevice->IASetIndexBuffer(g_pIndexBuffer, DXGI_FORMAT_R32_UINT, 0);
+
+    // Set primitive topology
+    g_pd3dDevice->IASetPrimitiveTopology(D3D10_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+    // Apply state and draw
     D3D10_TECHNIQUE_DESC techDesc;
     g_pTechniqueRender->GetDesc( &techDesc );
     for( UINT p = 0; p < techDesc.Passes; ++p )

--- a/C++/Direct3D10/Tutorials/Tutorial07/Tutorial07.cpp
+++ b/C++/Direct3D10/Tutorials/Tutorial07/Tutorial07.cpp
@@ -25,23 +25,23 @@ struct SimpleVertex
 //--------------------------------------------------------------------------------------
 // Global Variables
 //--------------------------------------------------------------------------------------
-HINSTANCE                           g_hInst = NULL;
-HWND                                g_hWnd = NULL;
+HINSTANCE                           g_hInst = nullptr;
+HWND                                g_hWnd = nullptr;
 D3D10_DRIVER_TYPE                   g_driverType = D3D10_DRIVER_TYPE_NULL;
-ID3D10Device*                       g_pd3dDevice = NULL;
-IDXGISwapChain*                     g_pSwapChain = NULL;
-ID3D10RenderTargetView*             g_pRenderTargetView = NULL;
-ID3D10Effect*                       g_pEffect = NULL;
-ID3D10EffectTechnique*              g_pTechnique = NULL;
-ID3D10InputLayout*                  g_pVertexLayout = NULL;
-ID3D10Buffer*                       g_pVertexBuffer = NULL;
-ID3D10Buffer*                       g_pIndexBuffer = NULL;
-ID3D10ShaderResourceView*           g_pTextureRV = NULL;
-ID3D10EffectMatrixVariable*         g_pWorldVariable = NULL;
-ID3D10EffectMatrixVariable*         g_pViewVariable = NULL;
-ID3D10EffectMatrixVariable*         g_pProjectionVariable = NULL;
-ID3D10EffectVectorVariable*         g_pMeshColorVariable = NULL;
-ID3D10EffectShaderResourceVariable* g_pDiffuseVariable = NULL;
+ID3D10Device*                       g_pd3dDevice = nullptr;
+IDXGISwapChain*                     g_pSwapChain = nullptr;
+ID3D10RenderTargetView*             g_pRenderTargetView = nullptr;
+ID3D10Effect*                       g_pEffect = nullptr;
+ID3D10EffectTechnique*              g_pTechnique = nullptr;
+ID3D10InputLayout*                  g_pVertexLayout = nullptr;
+ID3D10Buffer*                       g_pVertexBuffer = nullptr;
+ID3D10Buffer*                       g_pIndexBuffer = nullptr;
+ID3D10ShaderResourceView*           g_pTextureRV = nullptr;
+ID3D10EffectMatrixVariable*         g_pWorldVariable = nullptr;
+ID3D10EffectMatrixVariable*         g_pViewVariable = nullptr;
+ID3D10EffectMatrixVariable*         g_pProjectionVariable = nullptr;
+ID3D10EffectVectorVariable*         g_pMeshColorVariable = nullptr;
+ID3D10EffectShaderResourceVariable* g_pDiffuseVariable = nullptr;
 D3DXMATRIX                          g_World;
 D3DXMATRIX                          g_View;
 D3DXMATRIX                          g_Projection;
@@ -77,10 +77,10 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
     }
 
     // Main message loop
-    MSG msg = {0};
+    MSG msg = {};
     while( WM_QUIT != msg.message )
     {
-        if( PeekMessage( &msg, NULL, 0, 0, PM_REMOVE ) )
+        if( PeekMessage( &msg, nullptr, 0, 0, PM_REMOVE ) )
         {
             TranslateMessage( &msg );
             DispatchMessage( &msg );
@@ -93,7 +93,7 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
 
     CleanupDevice();
 
-    return ( int )msg.wParam;
+    return static_cast<int>(msg.wParam);
 }
 
 
@@ -103,17 +103,15 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdL
 HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
 {
     // Register class
-    WNDCLASSEX wcex;
+    WNDCLASSEX wcex = {};
     wcex.cbSize = sizeof( WNDCLASSEX );
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon( hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
-    wcex.hCursor = LoadCursor( NULL, IDC_ARROW );
+    wcex.hCursor = LoadCursor( nullptr, IDC_ARROW );
     wcex.hbrBackground = ( HBRUSH )( COLOR_WINDOW + 1 );
-    wcex.lpszMenuName = NULL;
+    wcex.lpszMenuName = nullptr;
     wcex.lpszClassName = L"TutorialWindowClass";
     wcex.hIconSm = LoadIcon( wcex.hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
     if( !RegisterClassEx( &wcex ) )
@@ -124,8 +122,8 @@ HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
     RECT rc = { 0, 0, 640, 480 };
     AdjustWindowRect( &rc, WS_OVERLAPPEDWINDOW, FALSE );
     g_hWnd = CreateWindow( L"TutorialWindowClass", L"Direct3D 10 Tutorial 7", WS_OVERLAPPEDWINDOW,
-                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, NULL, NULL, hInstance,
-                           NULL );
+                           CW_USEDEFAULT, CW_USEDEFAULT, rc.right - rc.left, rc.bottom - rc.top, nullptr, nullptr, hInstance,
+                           nullptr );
     if( !g_hWnd )
         return E_FAIL;
 
@@ -159,8 +157,7 @@ HRESULT InitDevice()
     };
     UINT numDriverTypes = sizeof( driverTypes ) / sizeof( driverTypes[0] );
 
-    DXGI_SWAP_CHAIN_DESC sd;
-    ZeroMemory( &sd, sizeof( sd ) );
+    DXGI_SWAP_CHAIN_DESC sd = {};
     sd.BufferCount = 1;
     sd.BufferDesc.Width = width;
     sd.BufferDesc.Height = height;
@@ -176,7 +173,7 @@ HRESULT InitDevice()
     for( UINT driverTypeIndex = 0; driverTypeIndex < numDriverTypes; driverTypeIndex++ )
     {
         g_driverType = driverTypes[driverTypeIndex];
-        hr = D3D10CreateDeviceAndSwapChain( NULL, g_driverType, NULL, createDeviceFlags,
+        hr = D3D10CreateDeviceAndSwapChain( nullptr, g_driverType, nullptr, createDeviceFlags,
                                             D3D10_SDK_VERSION, &sd, &g_pSwapChain, &g_pd3dDevice );
         if( SUCCEEDED( hr ) )
             break;
@@ -190,12 +187,12 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    hr = g_pd3dDevice->CreateRenderTargetView( pBuffer, NULL, &g_pRenderTargetView );
+    hr = g_pd3dDevice->CreateRenderTargetView( pBuffer, nullptr, &g_pRenderTargetView );
     pBuffer->Release();
     if( FAILED( hr ) )
         return hr;
 
-    g_pd3dDevice->OMSetRenderTargets( 1, &g_pRenderTargetView, NULL );
+    g_pd3dDevice->OMSetRenderTargets( 1, &g_pRenderTargetView, nullptr );
 
     // Setup the viewport
     D3D10_VIEWPORT vp;
@@ -216,11 +213,11 @@ HRESULT InitDevice()
     // the release configuration of this program.
     dwShaderFlags |= D3D10_SHADER_DEBUG;
     #endif
-    hr = D3DX10CreateEffectFromFile( L"Tutorial07.fx", NULL, NULL, "fx_4_0", dwShaderFlags, 0, g_pd3dDevice, NULL,
-                                         NULL, &g_pEffect, NULL, NULL );
+    hr = D3DX10CreateEffectFromFile( L"Tutorial07.fx", nullptr, nullptr, "fx_4_0", dwShaderFlags, 0, g_pd3dDevice, nullptr,
+                                         nullptr, &g_pEffect, nullptr, nullptr );
     if( FAILED( hr ) )
     {
-        MessageBox( NULL,
+        MessageBox( nullptr,
                     L"The FX file cannot be located.  Please run this executable from the directory that contains the FX file.", L"Error", MB_OK );
         return hr;
     }
@@ -236,7 +233,7 @@ HRESULT InitDevice()
     g_pDiffuseVariable = g_pEffect->GetVariableByName( "txDiffuse" )->AsShaderResource();
 
     // Define the input layout
-    D3D10_INPUT_ELEMENT_DESC layout[] =
+    const D3D10_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D10_INPUT_PER_VERTEX_DATA, 0 },
         { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D10_INPUT_PER_VERTEX_DATA, 0 },
@@ -251,11 +248,8 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    // Set the input layout
-    g_pd3dDevice->IASetInputLayout( g_pVertexLayout );
-
     // Create vertex buffer
-    SimpleVertex vertices[] =
+    const SimpleVertex vertices[] =
     {
         { D3DXVECTOR3( -1.0f, 1.0f, -1.0f ), D3DXVECTOR2( 0.0f, 0.0f ) },
         { D3DXVECTOR3( 1.0f, 1.0f, -1.0f ), D3DXVECTOR2( 1.0f, 0.0f ) },
@@ -288,26 +282,19 @@ HRESULT InitDevice()
         { D3DXVECTOR3( -1.0f, 1.0f, 1.0f ), D3DXVECTOR2( 0.0f, 1.0f ) },
     };
 
-    D3D10_BUFFER_DESC bd;
+    D3D10_BUFFER_DESC bd = {};
     bd.Usage = D3D10_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( SimpleVertex ) * 24;
     bd.BindFlags = D3D10_BIND_VERTEX_BUFFER;
-    bd.CPUAccessFlags = 0;
-    bd.MiscFlags = 0;
-    D3D10_SUBRESOURCE_DATA InitData;
+
+    D3D10_SUBRESOURCE_DATA InitData = {};
     InitData.pSysMem = vertices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pVertexBuffer );
     if( FAILED( hr ) )
         return hr;
 
-    // Set vertex buffer
-    UINT stride = sizeof( SimpleVertex );
-    UINT offset = 0;
-    g_pd3dDevice->IASetVertexBuffers( 0, 1, &g_pVertexBuffer, &stride, &offset );
-
     // Create index buffer
-    // Create vertex buffer
-    DWORD indices[] =
+    const DWORD indices[] =
     {
         3,1,0,
         2,1,3,
@@ -330,21 +317,13 @@ HRESULT InitDevice()
     bd.Usage = D3D10_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( DWORD ) * 36;
     bd.BindFlags = D3D10_BIND_INDEX_BUFFER;
-    bd.CPUAccessFlags = 0;
-    bd.MiscFlags = 0;
     InitData.pSysMem = indices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pIndexBuffer );
     if( FAILED( hr ) )
         return hr;
 
-    // Set index buffer
-    g_pd3dDevice->IASetIndexBuffer( g_pIndexBuffer, DXGI_FORMAT_R32_UINT, 0 );
-
-    // Set primitive topology
-    g_pd3dDevice->IASetPrimitiveTopology( D3D10_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
-
     // Load the Texture
-    hr = D3DX10CreateShaderResourceViewFromFile( g_pd3dDevice, L"seafloor.dds", NULL, NULL, &g_pTextureRV, NULL );
+    hr = D3DX10CreateShaderResourceViewFromFile( g_pd3dDevice, L"seafloor.dds", nullptr, nullptr, &g_pTextureRV, nullptr );
     if( FAILED( hr ) )
         return hr;
 
@@ -457,6 +436,22 @@ void Render()
     //
     // Render the cube
     //
+
+    // Set the input layout
+    g_pd3dDevice->IASetInputLayout(g_pVertexLayout);
+
+    // Set vertex buffer
+    UINT stride = sizeof(SimpleVertex);
+    UINT offset = 0;
+    g_pd3dDevice->IASetVertexBuffers(0, 1, &g_pVertexBuffer, &stride, &offset);
+
+    // Set index buffer
+    g_pd3dDevice->IASetIndexBuffer(g_pIndexBuffer, DXGI_FORMAT_R32_UINT, 0);
+
+    // Set primitive topology
+    g_pd3dDevice->IASetPrimitiveTopology(D3D10_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+    // Apply state and draw
     D3D10_TECHNIQUE_DESC techDesc;
     g_pTechnique->GetDesc( &techDesc );
     for( UINT p = 0; p < techDesc.Passes; ++p )

--- a/C++/Direct3D10/Tutorials/Tutorial08/Tutorial08.cpp
+++ b/C++/Direct3D10/Tutorials/Tutorial08/Tutorial08.cpp
@@ -144,7 +144,7 @@ HRESULT CALLBACK OnD3D10CreateDevice( ID3D10Device* pd3dDevice, const DXGI_SURFA
     g_pDiffuseVariable = g_pEffect->GetVariableByName( "txDiffuse" )->AsShaderResource();
 
     // Define the input layout
-    D3D10_INPUT_ELEMENT_DESC layout[] =
+    const D3D10_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D10_INPUT_PER_VERTEX_DATA, 0 },
         { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D10_INPUT_PER_VERTEX_DATA, 0 },

--- a/C++/Direct3D11/Tutorials/Tutorial01/Tutorial01.cpp
+++ b/C++/Direct3D11/Tutorials/Tutorial01/Tutorial01.cpp
@@ -65,7 +65,7 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
     }
 
     // Main message loop
-    MSG msg = {0};
+    MSG msg = {};
     while( WM_QUIT != msg.message )
     {
         if( PeekMessage( &msg, nullptr, 0, 0, PM_REMOVE ) )
@@ -81,7 +81,7 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 
     CleanupDevice();
 
-    return ( int )msg.wParam;
+    return static_cast<int>(msg.wParam);
 }
 
 
@@ -91,12 +91,10 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
 {
     // Register class
-    WNDCLASSEX wcex;
+    WNDCLASSEX wcex = {};
     wcex.cbSize = sizeof( WNDCLASSEX );
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon( hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
     wcex.hCursor = LoadCursor( nullptr, IDC_ARROW );
@@ -297,9 +295,9 @@ HRESULT InitDevice()
     g_pImmediateContext->OMSetRenderTargets( 1, &g_pRenderTargetView, nullptr );
 
     // Setup the viewport
-    D3D11_VIEWPORT vp;
-    vp.Width = (FLOAT)width;
-    vp.Height = (FLOAT)height;
+    D3D11_VIEWPORT vp = {};
+    vp.Width = static_cast<FLOAT>(width);
+    vp.Height = static_cast<FLOAT>(height);
     vp.MinDepth = 0.0f;
     vp.MaxDepth = 1.0f;
     vp.TopLeftX = 0;

--- a/C++/Direct3D11/Tutorials/Tutorial02/Tutorial02.cpp
+++ b/C++/Direct3D11/Tutorials/Tutorial02/Tutorial02.cpp
@@ -80,7 +80,7 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
     }
 
     // Main message loop
-    MSG msg = {0};
+    MSG msg = {};
     while( WM_QUIT != msg.message )
     {
         if( PeekMessage( &msg, nullptr, 0, 0, PM_REMOVE ) )
@@ -96,7 +96,7 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 
     CleanupDevice();
 
-    return ( int )msg.wParam;
+    return static_cast<int>(msg.wParam);
 }
 
 
@@ -106,12 +106,10 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
 {
     // Register class
-    WNDCLASSEX wcex;
+    WNDCLASSEX wcex = {};
     wcex.cbSize = sizeof( WNDCLASSEX );
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon( hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
     wcex.hCursor = LoadCursor( nullptr, IDC_ARROW );
@@ -321,9 +319,9 @@ HRESULT InitDevice()
     g_pImmediateContext->OMSetRenderTargets( 1, &g_pRenderTargetView, nullptr );
 
     // Setup the viewport
-    D3D11_VIEWPORT vp;
-    vp.Width = (FLOAT)width;
-    vp.Height = (FLOAT)height;
+    D3D11_VIEWPORT vp = {};
+    vp.Width = static_cast<FLOAT>(width);
+    vp.Height = static_cast<FLOAT>(height);
     vp.MinDepth = 0.0f;
     vp.MaxDepth = 1.0f;
     vp.TopLeftX = 0;
@@ -349,7 +347,7 @@ HRESULT InitDevice()
 	}
 
     // Define the input layout
-    D3D11_INPUT_ELEMENT_DESC layout[] =
+    const D3D11_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
     };
@@ -361,9 +359,6 @@ HRESULT InitDevice()
 	pVSBlob->Release();
 	if( FAILED( hr ) )
         return hr;
-
-    // Set the input layout
-    g_pImmediateContext->IASetInputLayout( g_pVertexLayout );
 
 	// Compile the pixel shader
 	ID3DBlob* pPSBlob = nullptr;
@@ -382,7 +377,7 @@ HRESULT InitDevice()
         return hr;
 
     // Create vertex buffer
-    SimpleVertex vertices[] =
+    const SimpleVertex vertices[] =
     {
         XMFLOAT3( 0.0f, 0.5f, 0.5f ),
         XMFLOAT3( 0.5f, -0.5f, 0.5f ),
@@ -392,21 +387,12 @@ HRESULT InitDevice()
     bd.Usage = D3D11_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( SimpleVertex ) * 3;
     bd.BindFlags = D3D11_BIND_VERTEX_BUFFER;
-	bd.CPUAccessFlags = 0;
 
     D3D11_SUBRESOURCE_DATA InitData = {};
     InitData.pSysMem = vertices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pVertexBuffer );
     if( FAILED( hr ) )
         return hr;
-
-    // Set vertex buffer
-    UINT stride = sizeof( SimpleVertex );
-    UINT offset = 0;
-    g_pImmediateContext->IASetVertexBuffers( 0, 1, &g_pVertexBuffer, &stride, &offset );
-
-    // Set primitive topology
-    g_pImmediateContext->IASetPrimitiveTopology( D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 
     return S_OK;
 }
@@ -470,6 +456,17 @@ void Render()
 {
     // Clear the back buffer 
     g_pImmediateContext->ClearRenderTargetView( g_pRenderTargetView, Colors::MidnightBlue );
+
+    // Set the input layout
+    g_pImmediateContext->IASetInputLayout(g_pVertexLayout);
+
+    // Set vertex buffer
+    UINT stride = sizeof(SimpleVertex);
+    UINT offset = 0;
+    g_pImmediateContext->IASetVertexBuffers(0, 1, &g_pVertexBuffer, &stride, &offset);
+
+    // Set primitive topology
+    g_pImmediateContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
     // Render a triangle
 	g_pImmediateContext->VSSetShader( g_pVertexShader, nullptr, 0 );

--- a/C++/Direct3D11/Tutorials/Tutorial03/Tutorial03.cpp
+++ b/C++/Direct3D11/Tutorials/Tutorial03/Tutorial03.cpp
@@ -80,7 +80,7 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
     }
 
     // Main message loop
-    MSG msg = {0};
+    MSG msg = {};
     while( WM_QUIT != msg.message )
     {
         if( PeekMessage( &msg, nullptr, 0, 0, PM_REMOVE ) )
@@ -96,7 +96,7 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 
     CleanupDevice();
 
-    return ( int )msg.wParam;
+    return static_cast<int>(msg.wParam);
 }
 
 
@@ -106,12 +106,10 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
 {
     // Register class
-    WNDCLASSEX wcex;
+    WNDCLASSEX wcex = {};
     wcex.cbSize = sizeof( WNDCLASSEX );
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon( hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
     wcex.hCursor = LoadCursor( nullptr, IDC_ARROW );
@@ -321,9 +319,9 @@ HRESULT InitDevice()
     g_pImmediateContext->OMSetRenderTargets( 1, &g_pRenderTargetView, nullptr );
 
     // Setup the viewport
-    D3D11_VIEWPORT vp;
-    vp.Width = (FLOAT)width;
-    vp.Height = (FLOAT)height;
+    D3D11_VIEWPORT vp = {};
+    vp.Width = static_cast<FLOAT>(width);
+    vp.Height = static_cast<FLOAT>(height);
     vp.MinDepth = 0.0f;
     vp.MaxDepth = 1.0f;
     vp.TopLeftX = 0;
@@ -349,7 +347,7 @@ HRESULT InitDevice()
 	}
 
     // Define the input layout
-    D3D11_INPUT_ELEMENT_DESC layout[] =
+    const D3D11_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
     };
@@ -361,9 +359,6 @@ HRESULT InitDevice()
 	pVSBlob->Release();
 	if( FAILED( hr ) )
         return hr;
-
-    // Set the input layout
-    g_pImmediateContext->IASetInputLayout( g_pVertexLayout );
 
 	// Compile the pixel shader
 	ID3DBlob* pPSBlob = nullptr;
@@ -382,7 +377,7 @@ HRESULT InitDevice()
         return hr;
 
     // Create vertex buffer
-    SimpleVertex vertices[] =
+    const SimpleVertex vertices[] =
     {
         XMFLOAT3( 0.0f, 0.5f, 0.5f ),
         XMFLOAT3( 0.5f, -0.5f, 0.5f ),
@@ -392,21 +387,12 @@ HRESULT InitDevice()
     bd.Usage = D3D11_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( SimpleVertex ) * 3;
     bd.BindFlags = D3D11_BIND_VERTEX_BUFFER;
-	bd.CPUAccessFlags = 0;
 
     D3D11_SUBRESOURCE_DATA InitData = {};
     InitData.pSysMem = vertices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pVertexBuffer );
     if( FAILED( hr ) )
         return hr;
-
-    // Set vertex buffer
-    UINT stride = sizeof( SimpleVertex );
-    UINT offset = 0;
-    g_pImmediateContext->IASetVertexBuffers( 0, 1, &g_pVertexBuffer, &stride, &offset );
-
-    // Set primitive topology
-    g_pImmediateContext->IASetPrimitiveTopology( D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 
     return S_OK;
 }
@@ -469,7 +455,18 @@ LRESULT CALLBACK WndProc( HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam 
 void Render()
 {
     // Clear the back buffer 
-        g_pImmediateContext->ClearRenderTargetView( g_pRenderTargetView, Colors::MidnightBlue );
+    g_pImmediateContext->ClearRenderTargetView( g_pRenderTargetView, Colors::MidnightBlue );
+
+    // Set the input layout
+    g_pImmediateContext->IASetInputLayout(g_pVertexLayout);
+
+    // Set vertex buffer
+    UINT stride = sizeof(SimpleVertex);
+    UINT offset = 0;
+    g_pImmediateContext->IASetVertexBuffers(0, 1, &g_pVertexBuffer, &stride, &offset);
+
+    // Set primitive topology
+    g_pImmediateContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
     // Render a triangle
 	g_pImmediateContext->VSSetShader( g_pVertexShader, nullptr, 0 );

--- a/C++/Direct3D11/Tutorials/Tutorial04/Tutorial04.cpp
+++ b/C++/Direct3D11/Tutorials/Tutorial04/Tutorial04.cpp
@@ -94,7 +94,7 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
     }
 
     // Main message loop
-    MSG msg = {0};
+    MSG msg = {};
     while( WM_QUIT != msg.message )
     {
         if( PeekMessage( &msg, nullptr, 0, 0, PM_REMOVE ) )
@@ -110,7 +110,7 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 
     CleanupDevice();
 
-    return ( int )msg.wParam;
+    return static_cast<int>(msg.wParam);
 }
 
 
@@ -120,12 +120,10 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
 {
     // Register class
-    WNDCLASSEX wcex;
+    WNDCLASSEX wcex = {};
     wcex.cbSize = sizeof( WNDCLASSEX );
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon( hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
     wcex.hCursor = LoadCursor( nullptr, IDC_ARROW );
@@ -335,9 +333,9 @@ HRESULT InitDevice()
     g_pImmediateContext->OMSetRenderTargets( 1, &g_pRenderTargetView, nullptr );
 
     // Setup the viewport
-    D3D11_VIEWPORT vp;
-    vp.Width = (FLOAT)width;
-    vp.Height = (FLOAT)height;
+    D3D11_VIEWPORT vp = {};
+    vp.Width = static_cast<FLOAT>(width);
+    vp.Height = static_cast<FLOAT>(height);
     vp.MinDepth = 0.0f;
     vp.MaxDepth = 1.0f;
     vp.TopLeftX = 0;
@@ -363,7 +361,7 @@ HRESULT InitDevice()
 	}
 
     // Define the input layout
-    D3D11_INPUT_ELEMENT_DESC layout[] =
+    const D3D11_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
         { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
@@ -376,9 +374,6 @@ HRESULT InitDevice()
 	pVSBlob->Release();
 	if( FAILED( hr ) )
         return hr;
-
-    // Set the input layout
-    g_pImmediateContext->IASetInputLayout( g_pVertexLayout );
 
 	// Compile the pixel shader
 	ID3DBlob* pPSBlob = nullptr;
@@ -397,7 +392,7 @@ HRESULT InitDevice()
         return hr;
 
     // Create vertex buffer
-    SimpleVertex vertices[] =
+    const SimpleVertex vertices[] =
     {
         { XMFLOAT3( -1.0f, 1.0f, -1.0f ), XMFLOAT4( 0.0f, 0.0f, 1.0f, 1.0f ) },
         { XMFLOAT3( 1.0f, 1.0f, -1.0f ), XMFLOAT4( 0.0f, 1.0f, 0.0f, 1.0f ) },
@@ -412,7 +407,6 @@ HRESULT InitDevice()
     bd.Usage = D3D11_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( SimpleVertex ) * 8;
     bd.BindFlags = D3D11_BIND_VERTEX_BUFFER;
-	bd.CPUAccessFlags = 0;
 
     D3D11_SUBRESOURCE_DATA InitData = {};
     InitData.pSysMem = vertices;
@@ -420,13 +414,8 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    // Set vertex buffer
-    UINT stride = sizeof( SimpleVertex );
-    UINT offset = 0;
-    g_pImmediateContext->IASetVertexBuffers( 0, 1, &g_pVertexBuffer, &stride, &offset );
-
     // Create index buffer
-    WORD indices[] =
+    const WORD indices[] =
     {
         3,1,0,
         2,1,3,
@@ -449,23 +438,15 @@ HRESULT InitDevice()
     bd.Usage = D3D11_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( WORD ) * 36;        // 36 vertices needed for 12 triangles in a triangle list
     bd.BindFlags = D3D11_BIND_INDEX_BUFFER;
-	bd.CPUAccessFlags = 0;
     InitData.pSysMem = indices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pIndexBuffer );
     if( FAILED( hr ) )
         return hr;
 
-    // Set index buffer
-    g_pImmediateContext->IASetIndexBuffer( g_pIndexBuffer, DXGI_FORMAT_R16_UINT, 0 );
-
-    // Set primitive topology
-    g_pImmediateContext->IASetPrimitiveTopology( D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
-
 	// Create the constant buffer
 	bd.Usage = D3D11_USAGE_DEFAULT;
 	bd.ByteWidth = sizeof(ConstantBuffer);
 	bd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
-	bd.CPUAccessFlags = 0;
     hr = g_pd3dDevice->CreateBuffer( &bd, nullptr, &g_pConstantBuffer );
     if( FAILED( hr ) )
         return hr;
@@ -572,11 +553,25 @@ void Render()
     //
     // Update variables
     //
-    ConstantBuffer cb;
+    ConstantBuffer cb = {};
 	cb.mWorld = XMMatrixTranspose( g_World );
 	cb.mView = XMMatrixTranspose( g_View );
 	cb.mProjection = XMMatrixTranspose( g_Projection );
 	g_pImmediateContext->UpdateSubresource( g_pConstantBuffer, 0, nullptr, &cb, 0, 0 );
+
+    // Set the input layout
+    g_pImmediateContext->IASetInputLayout(g_pVertexLayout);
+
+    // Set vertex buffer
+    UINT stride = sizeof(SimpleVertex);
+    UINT offset = 0;
+    g_pImmediateContext->IASetVertexBuffers(0, 1, &g_pVertexBuffer, &stride, &offset);
+
+    // Set index buffer
+    g_pImmediateContext->IASetIndexBuffer(g_pIndexBuffer, DXGI_FORMAT_R16_UINT, 0);
+
+        // Set primitive topology
+    g_pImmediateContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
     //
     // Renders a triangle

--- a/C++/Direct3D11/Tutorials/Tutorial05/Tutorial05.cpp
+++ b/C++/Direct3D11/Tutorials/Tutorial05/Tutorial05.cpp
@@ -97,7 +97,7 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
     }
 
     // Main message loop
-    MSG msg = {0};
+    MSG msg = {};
     while( WM_QUIT != msg.message )
     {
         if( PeekMessage( &msg, nullptr, 0, 0, PM_REMOVE ) )
@@ -113,7 +113,7 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 
     CleanupDevice();
 
-    return ( int )msg.wParam;
+    return static_cast<int>(msg.wParam);
 }
 
 
@@ -123,12 +123,10 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
 {
     // Register class
-    WNDCLASSEX wcex;
+    WNDCLASSEX wcex = {};
     wcex.cbSize = sizeof( WNDCLASSEX );
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon( hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
     wcex.hCursor = LoadCursor( nullptr, IDC_ARROW );
@@ -364,9 +362,9 @@ HRESULT InitDevice()
     g_pImmediateContext->OMSetRenderTargets( 1, &g_pRenderTargetView, g_pDepthStencilView );
 
     // Setup the viewport
-    D3D11_VIEWPORT vp;
-    vp.Width = (FLOAT)width;
-    vp.Height = (FLOAT)height;
+    D3D11_VIEWPORT vp = {};
+    vp.Width = static_cast<FLOAT>(width);
+    vp.Height = static_cast<FLOAT>(height);
     vp.MinDepth = 0.0f;
     vp.MaxDepth = 1.0f;
     vp.TopLeftX = 0;
@@ -392,7 +390,7 @@ HRESULT InitDevice()
 	}
 
     // Define the input layout
-    D3D11_INPUT_ELEMENT_DESC layout[] =
+    const D3D11_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
         { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
@@ -405,9 +403,6 @@ HRESULT InitDevice()
 	pVSBlob->Release();
 	if( FAILED( hr ) )
         return hr;
-
-    // Set the input layout
-    g_pImmediateContext->IASetInputLayout( g_pVertexLayout );
 
 	// Compile the pixel shader
 	ID3DBlob* pPSBlob = nullptr;
@@ -426,7 +421,7 @@ HRESULT InitDevice()
         return hr;
 
     // Create vertex buffer
-    SimpleVertex vertices[] =
+    const SimpleVertex vertices[] =
     {
         { XMFLOAT3( -1.0f, 1.0f, -1.0f ), XMFLOAT4( 0.0f, 0.0f, 1.0f, 1.0f ) },
         { XMFLOAT3( 1.0f, 1.0f, -1.0f ), XMFLOAT4( 0.0f, 1.0f, 0.0f, 1.0f ) },
@@ -441,7 +436,6 @@ HRESULT InitDevice()
     bd.Usage = D3D11_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( SimpleVertex ) * 8;
     bd.BindFlags = D3D11_BIND_VERTEX_BUFFER;
-	bd.CPUAccessFlags = 0;
 
     D3D11_SUBRESOURCE_DATA InitData = {};
     InitData.pSysMem = vertices;
@@ -449,13 +443,8 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    // Set vertex buffer
-    UINT stride = sizeof( SimpleVertex );
-    UINT offset = 0;
-    g_pImmediateContext->IASetVertexBuffers( 0, 1, &g_pVertexBuffer, &stride, &offset );
-
     // Create index buffer
-    WORD indices[] =
+    const WORD indices[] =
     {
         3,1,0,
         2,1,3,
@@ -478,23 +467,15 @@ HRESULT InitDevice()
     bd.Usage = D3D11_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( WORD ) * 36;        // 36 vertices needed for 12 triangles in a triangle list
     bd.BindFlags = D3D11_BIND_INDEX_BUFFER;
-	bd.CPUAccessFlags = 0;
     InitData.pSysMem = indices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pIndexBuffer );
     if( FAILED( hr ) )
         return hr;
 
-    // Set index buffer
-    g_pImmediateContext->IASetIndexBuffer( g_pIndexBuffer, DXGI_FORMAT_R16_UINT, 0 );
-
-    // Set primitive topology
-    g_pImmediateContext->IASetPrimitiveTopology( D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
-
 	// Create the constant buffer
 	bd.Usage = D3D11_USAGE_DEFAULT;
 	bd.ByteWidth = sizeof(ConstantBuffer);
 	bd.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
-	bd.CPUAccessFlags = 0;
     hr = g_pd3dDevice->CreateBuffer( &bd, nullptr, &g_pConstantBuffer );
     if( FAILED( hr ) )
         return hr;
@@ -615,11 +596,25 @@ void Render()
     //
     // Update variables for the first cube
     //
-    ConstantBuffer cb1;
+    ConstantBuffer cb1 = {};
 	cb1.mWorld = XMMatrixTranspose( g_World1 );
 	cb1.mView = XMMatrixTranspose( g_View );
 	cb1.mProjection = XMMatrixTranspose( g_Projection );
 	g_pImmediateContext->UpdateSubresource( g_pConstantBuffer, 0, nullptr, &cb1, 0, 0 );
+
+    // Set the input layout
+    g_pImmediateContext->IASetInputLayout(g_pVertexLayout);
+
+    // Set vertex buffer
+    UINT stride = sizeof(SimpleVertex);
+    UINT offset = 0;
+    g_pImmediateContext->IASetVertexBuffers(0, 1, &g_pVertexBuffer, &stride, &offset);
+
+    // Set index buffer
+    g_pImmediateContext->IASetIndexBuffer(g_pIndexBuffer, DXGI_FORMAT_R16_UINT, 0);
+
+    // Set primitive topology
+    g_pImmediateContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
     //
     // Render the first cube
@@ -632,7 +627,7 @@ void Render()
     //
     // Update variables for the second cube
     //
-    ConstantBuffer cb2;
+    ConstantBuffer cb2 = {};
 	cb2.mWorld = XMMatrixTranspose( g_World2 );
 	cb2.mView = XMMatrixTranspose( g_View );
 	cb2.mProjection = XMMatrixTranspose( g_Projection );

--- a/C++/Direct3D11/Tutorials/Tutorial06/Tutorial06.cpp
+++ b/C++/Direct3D11/Tutorials/Tutorial06/Tutorial06.cpp
@@ -100,7 +100,7 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
     }
 
     // Main message loop
-    MSG msg = {0};
+    MSG msg = {};
     while( WM_QUIT != msg.message )
     {
         if( PeekMessage( &msg, nullptr, 0, 0, PM_REMOVE ) )
@@ -116,7 +116,7 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 
     CleanupDevice();
 
-    return ( int )msg.wParam;
+    return static_cast<int>(msg.wParam);
 }
 
 
@@ -126,12 +126,10 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
 {
     // Register class
-    WNDCLASSEX wcex;
+    WNDCLASSEX wcex = {};
     wcex.cbSize = sizeof( WNDCLASSEX );
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon( hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
     wcex.hCursor = LoadCursor( nullptr, IDC_ARROW );
@@ -367,9 +365,9 @@ HRESULT InitDevice()
     g_pImmediateContext->OMSetRenderTargets( 1, &g_pRenderTargetView, g_pDepthStencilView );
 
     // Setup the viewport
-    D3D11_VIEWPORT vp;
-    vp.Width = (FLOAT)width;
-    vp.Height = (FLOAT)height;
+    D3D11_VIEWPORT vp = {};
+    vp.Width = static_cast<FLOAT>(width);
+    vp.Height = static_cast<FLOAT>(height);
     vp.MinDepth = 0.0f;
     vp.MaxDepth = 1.0f;
     vp.TopLeftX = 0;
@@ -395,7 +393,7 @@ HRESULT InitDevice()
 	}
 
     // Define the input layout
-    D3D11_INPUT_ELEMENT_DESC layout[] =
+    const D3D11_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
         { "NORMAL", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
@@ -408,9 +406,6 @@ HRESULT InitDevice()
 	pVSBlob->Release();
 	if( FAILED( hr ) )
         return hr;
-
-    // Set the input layout
-    g_pImmediateContext->IASetInputLayout( g_pVertexLayout );
 
 	// Compile the pixel shader
 	ID3DBlob* pPSBlob = nullptr;
@@ -445,7 +440,7 @@ HRESULT InitDevice()
         return hr;
 
     // Create vertex buffer
-    SimpleVertex vertices[] =
+    const SimpleVertex vertices[] =
     {
         { XMFLOAT3( -1.0f, 1.0f, -1.0f ), XMFLOAT3( 0.0f, 1.0f, 0.0f ) },
         { XMFLOAT3( 1.0f, 1.0f, -1.0f ), XMFLOAT3( 0.0f, 1.0f, 0.0f ) },
@@ -482,7 +477,6 @@ HRESULT InitDevice()
     bd.Usage = D3D11_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( SimpleVertex ) * 24;
     bd.BindFlags = D3D11_BIND_VERTEX_BUFFER;
-	bd.CPUAccessFlags = 0;
 
     D3D11_SUBRESOURCE_DATA InitData = {};
     InitData.pSysMem = vertices;
@@ -496,8 +490,7 @@ HRESULT InitDevice()
     g_pImmediateContext->IASetVertexBuffers( 0, 1, &g_pVertexBuffer, &stride, &offset );
 
     // Create index buffer
-    // Create vertex buffer
-    WORD indices[] =
+    const WORD indices[] =
     {
         3,1,0,
         2,1,3,
@@ -520,17 +513,10 @@ HRESULT InitDevice()
     bd.Usage = D3D11_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( WORD ) * 36;        // 36 vertices needed for 12 triangles in a triangle list
     bd.BindFlags = D3D11_BIND_INDEX_BUFFER;
-	bd.CPUAccessFlags = 0;
     InitData.pSysMem = indices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pIndexBuffer );
     if( FAILED( hr ) )
         return hr;
-
-    // Set index buffer
-    g_pImmediateContext->IASetIndexBuffer( g_pIndexBuffer, DXGI_FORMAT_R16_UINT, 0 );
-
-    // Set primitive topology
-    g_pImmediateContext->IASetPrimitiveTopology( D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 
 	// Create the constant buffer
 	bd.Usage = D3D11_USAGE_DEFAULT;
@@ -668,7 +654,7 @@ void Render()
     //
     // Update matrix variables and lighting variables
     //
-    ConstantBuffer cb1;
+    ConstantBuffer cb1 = {};
 	cb1.mWorld = XMMatrixTranspose( g_World );
 	cb1.mView = XMMatrixTranspose( g_View );
 	cb1.mProjection = XMMatrixTranspose( g_Projection );
@@ -678,6 +664,20 @@ void Render()
 	cb1.vLightColor[1] = vLightColors[1];
 	cb1.vOutputColor = XMFLOAT4(0, 0, 0, 0);
 	g_pImmediateContext->UpdateSubresource( g_pConstantBuffer, 0, nullptr, &cb1, 0, 0 );
+
+    // Set the input layout
+    g_pImmediateContext->IASetInputLayout(g_pVertexLayout);
+
+    // Set vertex buffer
+    UINT stride = sizeof(SimpleVertex);
+    UINT offset = 0;
+    g_pImmediateContext->IASetVertexBuffers(0, 1, &g_pVertexBuffer, &stride, &offset);
+
+    // Set index buffer
+    g_pImmediateContext->IASetIndexBuffer(g_pIndexBuffer, DXGI_FORMAT_R16_UINT, 0);
+
+    // Set primitive topology
+    g_pImmediateContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
     //
     // Render the cube

--- a/C++/Direct3D11/Tutorials/Tutorial07/DDSTextureLoader.h
+++ b/C++/Direct3D11/Tutorials/Tutorial07/DDSTextureLoader.h
@@ -18,6 +18,9 @@
 
 #include <d3d11_1.h>
 
+#pragma comment(lib,"dxguid.lib")
+
+#include <cstddef>
 #include <cstdint>
 
 
@@ -50,7 +53,7 @@ namespace DirectX
 #pragma clang diagnostic ignored "-Wdeprecated-dynamic-exception-spec"
 #endif
 
-    DEFINE_ENUM_FLAG_OPERATORS(DDS_LOADER_FLAGS);
+    DEFINE_ENUM_FLAG_OPERATORS(DDS_LOADER_FLAGS)
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/C++/Direct3D11/Tutorials/Tutorial07/Tutorial07.cpp
+++ b/C++/Direct3D11/Tutorials/Tutorial07/Tutorial07.cpp
@@ -110,7 +110,7 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
     }
 
     // Main message loop
-    MSG msg = {0};
+    MSG msg = {};
     while( WM_QUIT != msg.message )
     {
         if( PeekMessage( &msg, nullptr, 0, 0, PM_REMOVE ) )
@@ -126,7 +126,7 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 
     CleanupDevice();
 
-    return ( int )msg.wParam;
+    return static_cast<int>(msg.wParam);
 }
 
 
@@ -136,12 +136,10 @@ int WINAPI wWinMain( _In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
 HRESULT InitWindow( HINSTANCE hInstance, int nCmdShow )
 {
     // Register class
-    WNDCLASSEX wcex;
+    WNDCLASSEX wcex = {};
     wcex.cbSize = sizeof( WNDCLASSEX );
     wcex.style = CS_HREDRAW | CS_VREDRAW;
     wcex.lpfnWndProc = WndProc;
-    wcex.cbClsExtra = 0;
-    wcex.cbWndExtra = 0;
     wcex.hInstance = hInstance;
     wcex.hIcon = LoadIcon( hInstance, ( LPCTSTR )IDI_TUTORIAL1 );
     wcex.hCursor = LoadCursor( nullptr, IDC_ARROW );
@@ -377,9 +375,9 @@ HRESULT InitDevice()
     g_pImmediateContext->OMSetRenderTargets( 1, &g_pRenderTargetView, g_pDepthStencilView );
 
     // Setup the viewport
-    D3D11_VIEWPORT vp;
-    vp.Width = (FLOAT)width;
-    vp.Height = (FLOAT)height;
+    D3D11_VIEWPORT vp = {};
+    vp.Width = static_cast<FLOAT>(width);
+    vp.Height = static_cast<FLOAT>(height);
     vp.MinDepth = 0.0f;
     vp.MaxDepth = 1.0f;
     vp.TopLeftX = 0;
@@ -405,7 +403,7 @@ HRESULT InitDevice()
     }
 
     // Define the input layout
-    D3D11_INPUT_ELEMENT_DESC layout[] =
+    const D3D11_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
         { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
@@ -418,9 +416,6 @@ HRESULT InitDevice()
     pVSBlob->Release();
     if( FAILED( hr ) )
         return hr;
-
-    // Set the input layout
-    g_pImmediateContext->IASetInputLayout( g_pVertexLayout );
 
     // Compile the pixel shader
     ID3DBlob* pPSBlob = nullptr;
@@ -439,7 +434,7 @@ HRESULT InitDevice()
         return hr;
 
     // Create vertex buffer
-    SimpleVertex vertices[] =
+    const SimpleVertex vertices[] =
     {
         { XMFLOAT3( -1.0f, 1.0f, -1.0f ), XMFLOAT2( 1.0f, 0.0f ) },
         { XMFLOAT3( 1.0f, 1.0f, -1.0f ), XMFLOAT2( 0.0f, 0.0f ) },
@@ -476,7 +471,6 @@ HRESULT InitDevice()
     bd.Usage = D3D11_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( SimpleVertex ) * 24;
     bd.BindFlags = D3D11_BIND_VERTEX_BUFFER;
-    bd.CPUAccessFlags = 0;
 
     D3D11_SUBRESOURCE_DATA InitData = {};
     InitData.pSysMem = vertices;
@@ -484,14 +478,8 @@ HRESULT InitDevice()
     if( FAILED( hr ) )
         return hr;
 
-    // Set vertex buffer
-    UINT stride = sizeof( SimpleVertex );
-    UINT offset = 0;
-    g_pImmediateContext->IASetVertexBuffers( 0, 1, &g_pVertexBuffer, &stride, &offset );
-
     // Create index buffer
-    // Create vertex buffer
-    WORD indices[] =
+    const WORD indices[] =
     {
         3,1,0,
         2,1,3,
@@ -515,17 +503,10 @@ HRESULT InitDevice()
     bd.Usage = D3D11_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( WORD ) * 36;
     bd.BindFlags = D3D11_BIND_INDEX_BUFFER;
-    bd.CPUAccessFlags = 0;
     InitData.pSysMem = indices;
     hr = g_pd3dDevice->CreateBuffer( &bd, &InitData, &g_pIndexBuffer );
     if( FAILED( hr ) )
         return hr;
-
-    // Set index buffer
-    g_pImmediateContext->IASetIndexBuffer( g_pIndexBuffer, DXGI_FORMAT_R16_UINT, 0 );
-
-    // Set primitive topology
-    g_pImmediateContext->IASetPrimitiveTopology( D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 
     // Create the constant buffers
     bd.Usage = D3D11_USAGE_DEFAULT;
@@ -573,14 +554,14 @@ HRESULT InitDevice()
     XMVECTOR Up = XMVectorSet( 0.0f, 1.0f, 0.0f, 0.0f );
     g_View = XMMatrixLookAtLH( Eye, At, Up );
 
-    CBNeverChanges cbNeverChanges;
+    CBNeverChanges cbNeverChanges = {};
     cbNeverChanges.mView = XMMatrixTranspose( g_View );
     g_pImmediateContext->UpdateSubresource( g_pCBNeverChanges, 0, nullptr, &cbNeverChanges, 0, 0 );
 
     // Initialize the projection matrix
     g_Projection = XMMatrixPerspectiveFovLH( XM_PIDIV4, width / (FLOAT)height, 0.01f, 100.0f );
     
-    CBChangeOnResize cbChangesOnResize;
+    CBChangeOnResize cbChangesOnResize = {};
     cbChangesOnResize.mProjection = XMMatrixTranspose( g_Projection );
     g_pImmediateContext->UpdateSubresource( g_pCBChangeOnResize, 0, nullptr, &cbChangesOnResize, 0, 0 );
 
@@ -688,10 +669,24 @@ void Render()
     //
     // Update variables that change once per frame
     //
-    CBChangesEveryFrame cb;
+    CBChangesEveryFrame cb = {};
     cb.mWorld = XMMatrixTranspose( g_World );
     cb.vMeshColor = g_vMeshColor;
     g_pImmediateContext->UpdateSubresource( g_pCBChangesEveryFrame, 0, nullptr, &cb, 0, 0 );
+
+    // Set the input layout
+    g_pImmediateContext->IASetInputLayout(g_pVertexLayout);
+
+    // Set vertex buffer
+    UINT stride = sizeof(SimpleVertex);
+    UINT offset = 0;
+    g_pImmediateContext->IASetVertexBuffers(0, 1, &g_pVertexBuffer, &stride, &offset);
+
+    // Set index buffer
+    g_pImmediateContext->IASetIndexBuffer(g_pIndexBuffer, DXGI_FORMAT_R16_UINT, 0);
+
+    // Set primitive topology
+    g_pImmediateContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
     //
     // Render the cube

--- a/C++/Direct3D11/Tutorials/Tutorial08_DXUT/Tutorial08.cpp
+++ b/C++/Direct3D11/Tutorials/Tutorial08_DXUT/Tutorial08.cpp
@@ -79,8 +79,6 @@ HRESULT CALLBACK OnD3D11CreateDevice( ID3D11Device* pd3dDevice, const DXGI_SURFA
 {
     HRESULT hr = S_OK;
 
-    auto pd3dImmediateContext = DXUTGetD3D11DeviceContext();
-
     DWORD dwShaderFlags = D3DCOMPILE_ENABLE_STRICTNESS;
 #ifdef _DEBUG
     // Set the D3DCOMPILE_DEBUG flag to embed debug information in the shaders.
@@ -106,7 +104,7 @@ HRESULT CALLBACK OnD3D11CreateDevice( ID3D11Device* pd3dDevice, const DXGI_SURFA
     }
 
     // Define the input layout
-    D3D11_INPUT_ELEMENT_DESC layout[] =
+    const D3D11_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
         { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
@@ -120,9 +118,6 @@ HRESULT CALLBACK OnD3D11CreateDevice( ID3D11Device* pd3dDevice, const DXGI_SURFA
     if( FAILED( hr ) )
         return hr;
 
-    // Set the input layout
-    pd3dImmediateContext->IASetInputLayout( g_pVertexLayout );
-
     // Compile the pixel shader
     ID3DBlob* pPSBlob  = nullptr;
     V_RETURN( DXUTCompileFromFile( L"Tutorial08.fx", nullptr, "PS", "ps_4_0", dwShaderFlags, 0, &pPSBlob  ) );
@@ -134,7 +129,7 @@ HRESULT CALLBACK OnD3D11CreateDevice( ID3D11Device* pd3dDevice, const DXGI_SURFA
         return hr;
 
     // Create vertex buffer
-    SimpleVertex vertices[] =
+    const SimpleVertex vertices[] =
     {
         { XMFLOAT3( -1.0f, 1.0f, -1.0f ), XMFLOAT2( 1.0f, 0.0f ) },
         { XMFLOAT3( 1.0f, 1.0f, -1.0f ), XMFLOAT2( 0.0f, 0.0f ) },
@@ -171,19 +166,13 @@ HRESULT CALLBACK OnD3D11CreateDevice( ID3D11Device* pd3dDevice, const DXGI_SURFA
     bd.Usage = D3D11_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( SimpleVertex ) * 24;
     bd.BindFlags = D3D11_BIND_VERTEX_BUFFER;
-    bd.CPUAccessFlags = 0;
 
     D3D11_SUBRESOURCE_DATA InitData = {};
     InitData.pSysMem = vertices;
     V_RETURN( pd3dDevice->CreateBuffer( &bd, &InitData, &g_pVertexBuffer ) );
 
-    // Set vertex buffer
-    UINT stride = sizeof( SimpleVertex );
-    UINT offset = 0;
-    pd3dImmediateContext->IASetVertexBuffers( 0, 1, &g_pVertexBuffer, &stride, &offset );
-
     // Create index buffer
-    DWORD indices[] =
+    const DWORD indices[] =
     {
         3,1,0,
         2,1,3,
@@ -207,16 +196,8 @@ HRESULT CALLBACK OnD3D11CreateDevice( ID3D11Device* pd3dDevice, const DXGI_SURFA
     bd.Usage = D3D11_USAGE_DEFAULT;
     bd.ByteWidth = sizeof( DWORD ) * 36;
     bd.BindFlags = D3D11_BIND_INDEX_BUFFER;
-    bd.CPUAccessFlags = 0;
-    bd.MiscFlags = 0;
     InitData.pSysMem = indices;
     V_RETURN( pd3dDevice->CreateBuffer( &bd, &InitData, &g_pIndexBuffer ) );
-
-    // Set index buffer
-    pd3dImmediateContext->IASetIndexBuffer( g_pIndexBuffer, DXGI_FORMAT_R32_UINT, 0 );
-
-    // Set primitive topology
-    pd3dImmediateContext->IASetPrimitiveTopology( D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST );
 
     // Create the constant buffers
     bd.Usage = D3D11_USAGE_DYNAMIC;
@@ -310,6 +291,20 @@ void CALLBACK OnD3D11FrameRender( ID3D11Device* pd3dDevice, ID3D11DeviceContext*
     XMStoreFloat4x4( &pCB->mWorld, XMMatrixTranspose( g_World ) );
     pCB->vMeshColor = g_vMeshColor;
     pd3dImmediateContext->Unmap( g_pCBChangesEveryFrame , 0 );
+
+    // Set the input layout
+    pd3dImmediateContext->IASetInputLayout(g_pVertexLayout);
+
+    // Set vertex buffer
+    UINT stride = sizeof(SimpleVertex);
+    UINT offset = 0;
+    pd3dImmediateContext->IASetVertexBuffers(0, 1, &g_pVertexBuffer, &stride, &offset);
+
+    // Set index buffer
+    pd3dImmediateContext->IASetIndexBuffer(g_pIndexBuffer, DXGI_FORMAT_R32_UINT, 0);
+
+    // Set primitive topology
+    pd3dImmediateContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
     //
     // Render the cube

--- a/C++/Direct3D11/Tutorials/Tutorial09_DXUT/Tutorial09.cpp
+++ b/C++/Direct3D11/Tutorials/Tutorial09_DXUT/Tutorial09.cpp
@@ -104,7 +104,7 @@ HRESULT CALLBACK OnD3D11CreateDevice( ID3D11Device* pd3dDevice, const DXGI_SURFA
     }
 
     // Define the input layout
-    D3D11_INPUT_ELEMENT_DESC layout[] =
+    const D3D11_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
         { "NORMAL", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
@@ -118,9 +118,6 @@ HRESULT CALLBACK OnD3D11CreateDevice( ID3D11Device* pd3dDevice, const DXGI_SURFA
     SAFE_RELEASE( pVSBlob );
     if( FAILED( hr ) )
         return hr;
-
-    // Set the input layout
-    pd3dImmediateContext->IASetInputLayout( g_pVertexLayout );
 
     // Compile the pixel shader
     ID3DBlob* pPSBlob  = nullptr;

--- a/C++/Direct3D11/Tutorials/Tutorial10_DXUT/Tutorial10.cpp
+++ b/C++/Direct3D11/Tutorials/Tutorial10_DXUT/Tutorial10.cpp
@@ -139,7 +139,7 @@ HRESULT CALLBACK OnD3D11CreateDevice( ID3D11Device* pd3dDevice, const DXGI_SURFA
     }
 
     // Define the input layout
-    D3D11_INPUT_ELEMENT_DESC layout[] =
+    const D3D11_INPUT_ELEMENT_DESC layout[] =
     {
         { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
         { "NORMAL", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
@@ -153,9 +153,6 @@ HRESULT CALLBACK OnD3D11CreateDevice( ID3D11Device* pd3dDevice, const DXGI_SURFA
     SAFE_RELEASE( pVSBlob );
     if( FAILED( hr ) )
         return hr;
-
-    // Set the input layout
-    pd3dImmediateContext->IASetInputLayout( g_pVertexLayout );
 
     // Compile the pixel shader
     ID3DBlob* pPSBlob  = nullptr;


### PR DESCRIPTION
* Set draw state per frame and not just once
* Updated DDSTextureLoader for DX11
* Use C++11 `nullptr` instead of old-school `NULL`
* Use C++11 `={}` instead of `={0}` or `ZeroMemory`
* Use C++11 casts instead of old-school C casts
* Some use of const