### PR TITLE
GitHub Actions windows-2019 runner is being retired

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,9 @@ name: MSBuild
 
 on:
   push:
-    branches: [ "main" ]
+    branches: "main"
   pull_request:
-    branches: [ "main" ]
+    branches: "main"
     paths-ignore:
       - '*.md'
       - LICENSE
@@ -27,11 +27,14 @@ jobs:
         platform: [Win32, x64]
 
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
 
-    - name: Build
-      working-directory: ${{ github.workspace }}
-      run: msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }} ./BuildAllSolutions.targets
+      - name: Build
+        working-directory: ${{ github.workspace }}
+        run: >
+          msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }}
+          /p:SkipMFCProjects=true
+          BuildAllSolutions.targets

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,5 +36,4 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: >
           msbuild /m /p:Configuration=${{ matrix.build_type }} /p:Platform=${{ matrix.platform }}
-          /p:SkipMFCProjects=true
           BuildAllSolutions.targets

--- a/BuildAllSolutions.targets
+++ b/BuildAllSolutions.targets
@@ -10,12 +10,20 @@
   </ItemGroup>
 
   <ItemGroup>
+    <MFCSolutionList Include="$(MSBuildThisProjectDirectory)C++\DirectSound\**\*.sln" />
+  </ItemGroup>
+
+  <ItemGroup>
     <FullSolutionList Include="$(MSBuildThisProjectDirectory)**\*2019.sln" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Platform)'=='Win32'">
     <!-- These use 'x86' instead of 'Win32' in the SLN -->
     <FullSolutionList Remove="@(X86SolutionList)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SkipMFCProjects)'=='true'">
+    <FullSolutionList Remove="@(MFCSolutionList)" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/BuildAllSolutions.targets
+++ b/BuildAllSolutions.targets
@@ -10,21 +10,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <MFCSolutionList Include="$(MSBuildThisProjectDirectory)C++\DirectSound\**\*.sln" />
-    <MFCSolutionList Include="$(MSBuildThisProjectDirectory)C++\Misc\Autorun\*.sln" />
-  </ItemGroup>
-
-  <ItemGroup>
     <FullSolutionList Include="$(MSBuildThisProjectDirectory)**\*2019.sln" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Platform)'=='Win32'">
     <!-- These use 'x86' instead of 'Win32' in the SLN -->
     <FullSolutionList Remove="@(X86SolutionList)" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(SkipMFCProjects)'=='true'">
-    <FullSolutionList Remove="@(MFCSolutionList)" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/BuildAllSolutions.targets
+++ b/BuildAllSolutions.targets
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <MFCSolutionList Include="$(MSBuildThisProjectDirectory)C++\DirectSound\**\*.sln" />
+    <MFCSolutionList Include="$(MSBuildThisProjectDirectory)C++\Misc\Autorun\*.sln" />
   </ItemGroup>
 
   <ItemGroup>
@@ -58,4 +59,3 @@
       Targets="Clean" />
   </Target>
 </Project>
-

--- a/C++/DirectSound/adjustsound/adjustsound.rc
+++ b/C++/DirectSound/adjustsound/adjustsound.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <windows.h>
+#define IDC_STATIC -1
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/C++/DirectSound/adjustsound/adjustsound.rc
+++ b/C++/DirectSound/adjustsound/adjustsound.rc
@@ -164,18 +164,6 @@ END
 //
 // Generated from the TEXTINCLUDE 3 resource.
 //
-#define _AFX_NO_SPLITTER_RESOURCES
-#define _AFX_NO_OLE_RESOURCES
-#define _AFX_NO_TRACKER_RESOURCES
-#define _AFX_NO_PROPERTY_RESOURCES
 
-#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-#ifdef _WIN32
-LANGUAGE 9, 1
-#pragma code_page(1252)
-#endif
-#include "afxres.rc"         // Standard components
-#endif
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
-

--- a/C++/DirectSound/amplitudemodulation/amplitudemodulation.rc
+++ b/C++/DirectSound/amplitudemodulation/amplitudemodulation.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <windows.h>
+#define IDC_STATIC -1
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/C++/DirectSound/amplitudemodulation/amplitudemodulation.rc
+++ b/C++/DirectSound/amplitudemodulation/amplitudemodulation.rc
@@ -140,18 +140,6 @@ END
 //
 // Generated from the TEXTINCLUDE 3 resource.
 //
-#define _AFX_NO_SPLITTER_RESOURCES
-#define _AFX_NO_OLE_RESOURCES
-#define _AFX_NO_TRACKER_RESOURCES
-#define _AFX_NO_PROPERTY_RESOURCES
 
-#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-#ifdef _WIN32
-LANGUAGE 9, 1
-#pragma code_page(1252)
-#endif
-#include "afxres.rc"         // Standard components
-#endif
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
-

--- a/C++/DirectSound/capturesound/capturesound.rc
+++ b/C++/DirectSound/capturesound/capturesound.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <windows.h>
+#define IDC_STATIC -1
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/C++/DirectSound/capturesound/capturesound.rc
+++ b/C++/DirectSound/capturesound/capturesound.rc
@@ -179,18 +179,6 @@ END
 //
 // Generated from the TEXTINCLUDE 3 resource.
 //
-#define _AFX_NO_SPLITTER_RESOURCES
-#define _AFX_NO_OLE_RESOURCES
-#define _AFX_NO_TRACKER_RESOURCES
-#define _AFX_NO_PROPERTY_RESOURCES
 
-#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-#ifdef _WIN32
-LANGUAGE 9, 1
-#pragma code_page(1252)
-#endif
-#include "afxres.rc"         // Standard components
-#endif
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
-

--- a/C++/DirectSound/enumdevices/enumdevices.rc
+++ b/C++/DirectSound/enumdevices/enumdevices.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <windows.h>
+#define IDC_STATIC -1
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/C++/DirectSound/enumdevices/enumdevices.rc
+++ b/C++/DirectSound/enumdevices/enumdevices.rc
@@ -139,18 +139,6 @@ END
 //
 // Generated from the TEXTINCLUDE 3 resource.
 //
-#define _AFX_NO_SPLITTER_RESOURCES
-#define _AFX_NO_OLE_RESOURCES
-#define _AFX_NO_TRACKER_RESOURCES
-#define _AFX_NO_PROPERTY_RESOURCES
 
-#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-#ifdef _WIN32
-LANGUAGE 9, 1
-#pragma code_page(1252)
-#endif
-#include "afxres.rc"         // Standard components
-#endif
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
-

--- a/C++/DirectSound/fullduplexfilter/fullduplexfilter.rc
+++ b/C++/DirectSound/fullduplexfilter/fullduplexfilter.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <windows.h>
+#define IDC_STATIC -1
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/C++/DirectSound/fullduplexfilter/fullduplexfilter.rc
+++ b/C++/DirectSound/fullduplexfilter/fullduplexfilter.rc
@@ -165,18 +165,6 @@ END
 //
 // Generated from the TEXTINCLUDE 3 resource.
 //
-#define _AFX_NO_SPLITTER_RESOURCES
-#define _AFX_NO_OLE_RESOURCES
-#define _AFX_NO_TRACKER_RESOURCES
-#define _AFX_NO_PROPERTY_RESOURCES
 
-#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-#ifdef _WIN32
-LANGUAGE 9, 1
-#pragma code_page(1252)
-#endif
-#include "afxres.rc"         // Standard components
-#endif
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
-

--- a/C++/DirectSound/play3dsound/play3dsound.rc
+++ b/C++/DirectSound/play3dsound/play3dsound.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <windows.h>
+#define IDC_STATIC -1
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/C++/DirectSound/play3dsound/play3dsound.rc
+++ b/C++/DirectSound/play3dsound/play3dsound.rc
@@ -209,18 +209,6 @@ END
 //
 // Generated from the TEXTINCLUDE 3 resource.
 //
-#define _AFX_NO_SPLITTER_RESOURCES
-#define _AFX_NO_OLE_RESOURCES
-#define _AFX_NO_TRACKER_RESOURCES
-#define _AFX_NO_PROPERTY_RESOURCES
 
-#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-#ifdef _WIN32
-LANGUAGE 9, 1
-#pragma code_page(1252)
-#endif
-#include "afxres.rc"         // Standard components
-#endif
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
-

--- a/C++/DirectSound/playsound/playsound.rc
+++ b/C++/DirectSound/playsound/playsound.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <windows.h>
+#define IDC_STATIC -1
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/C++/DirectSound/playsound/playsound.rc
+++ b/C++/DirectSound/playsound/playsound.rc
@@ -125,18 +125,6 @@ END
 //
 // Generated from the TEXTINCLUDE 3 resource.
 //
-#define _AFX_NO_SPLITTER_RESOURCES
-#define _AFX_NO_OLE_RESOURCES
-#define _AFX_NO_TRACKER_RESOURCES
-#define _AFX_NO_PROPERTY_RESOURCES
 
-#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-#ifdef _WIN32
-LANGUAGE 9, 1
-#pragma code_page(1252)
-#endif
-#include "afxres.rc"         // Standard components
-#endif
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
-

--- a/C++/DirectSound/soundfx/soundfx.rc
+++ b/C++/DirectSound/soundfx/soundfx.rc
@@ -221,7 +221,5 @@ IDI_ICON                ICON                    "..\..\DXUT\Optional\directx.ico
 // Generated from the TEXTINCLUDE 3 resource.
 //
 
-
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
-

--- a/C++/DirectSound/voicemanagement/voicemanagement.rc
+++ b/C++/DirectSound/voicemanagement/voicemanagement.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <windows.h>
+#define IDC_STATIC -1
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/C++/DirectSound/voicemanagement/voicemanagement.rc
+++ b/C++/DirectSound/voicemanagement/voicemanagement.rc
@@ -160,18 +160,6 @@ END
 //
 // Generated from the TEXTINCLUDE 3 resource.
 //
-#define _AFX_NO_SPLITTER_RESOURCES
-#define _AFX_NO_OLE_RESOURCES
-#define _AFX_NO_TRACKER_RESOURCES
-#define _AFX_NO_PROPERTY_RESOURCES
 
-#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-#ifdef _WIN32
-LANGUAGE 9, 1
-#pragma code_page(1252)
-#endif
-#include "afxres.rc"         // Standard components
-#endif
 /////////////////////////////////////////////////////////////////////////////
 #endif    // not APSTUDIO_INVOKED
-

--- a/C++/Misc/Autorun/Autorun.rc
+++ b/C++/Misc/Autorun/Autorun.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <windows.h>
+#define IDC_STATIC -1
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/C++/Misc/Autorun/InstallerAndGame/Common.rc
+++ b/C++/Misc/Autorun/InstallerAndGame/Common.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <windows.h>
+#define IDC_STATIC -1
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/C++/Misc/DXInstall/dxinstall.rc
+++ b/C++/Misc/DXInstall/dxinstall.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <windows.h>
+#define IDC_STATIC -1
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/C++/Misc/GameStatisticsExample/GameStatisticsExample.cpp
+++ b/C++/Misc/GameStatisticsExample/GameStatisticsExample.cpp
@@ -3,7 +3,7 @@
 //
 // Sample code shows off the Windows 7 Game Explorer APIs - IGameStatistics and IGameStatisticsMgr.
 // The statistics can be seen in Windows 7 version of Game Explorer
-// 
+//
 // Copyright (c) Microsoft Corporation. All rights reserved.
 //--------------------------------------------------------------------------------------
 #define _WIN32_DCOM
@@ -13,34 +13,36 @@
 #include <shlobj.h>
 #include <shlwapi.h>
 #include <shellapi.h>
-#include <atlbase.h>
-#include <atlcom.h>
 #include <strsafe.h>
 #include <assert.h>
 #include <gameux.h>
 
+#include <wrl/client.h>
+
+using Microsoft::WRL::ComPtr;
+
 //--------------------------------------------------------------------------------------
 // Name: GetGDFBinaryPath
-// Desc: Gets the path of the GDF binary.  This sample uses Minesweeper for an example 
+// Desc: Gets the path of the GDF binary.  This sample uses Minesweeper for an example
 //       which is installed on most machines.  Change this to point to the GDF path of your title.
 //--------------------------------------------------------------------------------------
 HRESULT GetGDFBinaryPath(WCHAR* szGDFPath, int cchLength)
 {
     assert(szGDFPath);
     HRESULT hr;
-    
-    hr = SHGetFolderPath(NULL, CSIDL_PROGRAM_FILES, NULL, SHGFP_TYPE_CURRENT, szGDFPath);    
+
+    hr = SHGetFolderPath(NULL, CSIDL_PROGRAM_FILES, NULL, SHGFP_TYPE_CURRENT, szGDFPath);
     if (SUCCEEDED(hr))
     {
-        hr = StringCchCat(szGDFPath, cchLength, L"\\Microsoft Games\\Minesweeper\\Minesweeper.exe"); 
+        hr = StringCchCat(szGDFPath, cchLength, L"\\Microsoft Games\\Minesweeper\\Minesweeper.exe");
     }
-    
+
     return hr;
 }
 
 //--------------------------------------------------------------------------------------
 // Name: WriteStatistics
-// Desc: Writes statistics 
+// Desc: Writes statistics
 //--------------------------------------------------------------------------------------
 HRESULT WriteStatistics(IGameStatistics* piStats)
 {
@@ -51,26 +53,26 @@ HRESULT WriteStatistics(IGameStatistics* piStats)
     }
 
     HRESULT hr;
-    
+
     // These are example categories.  You can set up to 10 categories and name them as appropriate.
-    hr = piStats->SetCategoryTitle(0, L"Beginner");             
+    hr = piStats->SetCategoryTitle(0, L"Beginner");
     if (SUCCEEDED(hr))
     {
-        hr = piStats->SetCategoryTitle(1, L"Intermediate");                 
+        hr = piStats->SetCategoryTitle(1, L"Intermediate");
         if (SUCCEEDED(hr))
         {
-            hr = piStats->SetCategoryTitle(2, L"Advanced");                
+            hr = piStats->SetCategoryTitle(2, L"Advanced");
         }
     }
-    
+
     if (FAILED(hr))
         return hr;
 
-    // Statistic data would typically come from the game state and would be dependent on the category 
+    // Statistic data would typically come from the game state and would be dependent on the category
     // As a trivial example, we will write the same fixed data to all 3 categories
     for(WORD iCategory = 0; iCategory < 3; iCategory++)
     {
-        hr = piStats->SetStatistic(iCategory, 0, L"Best Time", L"150 second");                 
+        hr = piStats->SetStatistic(iCategory, 0, L"Best Time", L"150 second");
         if (SUCCEEDED(hr))
         {
             hr = piStats->SetStatistic(iCategory, 1, L"Games Played", L"40");
@@ -96,16 +98,16 @@ HRESULT WriteStatistics(IGameStatistics* piStats)
             }
         }
     }
-    
+
     if (SUCCEEDED(hr))
     {
-        hr = piStats->SetLastPlayedCategory(2);             
+        hr = piStats->SetLastPlayedCategory(2);
         if (SUCCEEDED(hr))
         {
-            hr = piStats->Save(TRUE);                       
+            hr = piStats->Save(TRUE);
         }
     }
-    
+
     return hr;
 }
 
@@ -124,11 +126,11 @@ HRESULT DisplayStatistics(IGameStatistics* piStats)
 
     WORD wMaxCategories = 0;
     WCHAR szStats[1024] = {0};
-    HRESULT hr = piStats->GetMaxCategories(&wMaxCategories);                        
+    HRESULT hr = piStats->GetMaxCategories(&wMaxCategories);
     for (WORD wIndex = 0; wIndex < wMaxCategories && SUCCEEDED(hr); wIndex++)
     {
         LPWSTR pCategory = NULL;
-        hr = piStats->GetCategoryTitle(wIndex, &pCategory);                         
+        hr = piStats->GetCategoryTitle(wIndex, &pCategory);
         if (SUCCEEDED(hr) && pCategory)
         {
             // If the category title is not NULL, display the statistics for this category
@@ -137,17 +139,17 @@ HRESULT DisplayStatistics(IGameStatistics* piStats)
 
             WORD wMaxStats;
             LPOLESTR pName = NULL;
-            LPOLESTR pValue = NULL;    
-            hr = piStats->GetMaxStatsPerCategory(&wMaxStats);                       
+            LPOLESTR pValue = NULL;
+            hr = piStats->GetMaxStatsPerCategory(&wMaxStats);
             for (WORD wStartIndex = 0; wStartIndex < wMaxStats && SUCCEEDED(hr); wStartIndex++)
             {
-                hr = piStats->GetStatistic(wIndex, wStartIndex, &pName, &pValue);   
+                hr = piStats->GetStatistic(wIndex, wStartIndex, &pName, &pValue);
                 if (SUCCEEDED(hr) && pName && pValue)
                 {
                     StringCchCat(szStats, ARRAYSIZE(szStats)-1, L"\t");
-                    StringCchCat(szStats, ARRAYSIZE(szStats)-1, pName);             
+                    StringCchCat(szStats, ARRAYSIZE(szStats)-1, pName);
                     StringCchCat(szStats, ARRAYSIZE(szStats)-1, L": ");
-                    StringCchCat(szStats, ARRAYSIZE(szStats)-1, pValue);            
+                    StringCchCat(szStats, ARRAYSIZE(szStats)-1, pValue);
                     StringCchCat(szStats, ARRAYSIZE(szStats)-1, L"\n");
                     CoTaskMemFree(pName);
                     CoTaskMemFree(pValue);
@@ -156,9 +158,9 @@ HRESULT DisplayStatistics(IGameStatistics* piStats)
             CoTaskMemFree(pCategory);
         }
     }
-    
-    MessageBox(NULL, szStats, L"Game Statistics", MB_OK);       
-    
+
+    MessageBox(NULL, szStats, L"Game Statistics", MB_OK);
+
     return hr;
 }
 
@@ -172,20 +174,20 @@ int __cdecl wmain()
     if (SUCCEEDED(hr))
     {
         WCHAR szGDFPath[MAX_PATH];
-        hr = GetGDFBinaryPath(szGDFPath, MAX_PATH);                                        
-        if (SUCCEEDED(hr) )       
+        hr = GetGDFBinaryPath(szGDFPath, MAX_PATH);
+        if (SUCCEEDED(hr) )
         {
             BSTR bstrGDFPath = SysAllocString(szGDFPath);
             if( bstrGDFPath )
-            {           
-                CComPtr<IGameStatisticsMgr> spiMgr;
-                hr = spiMgr.CoCreateInstance(__uuidof(GameStatistics));                 
+            {
+                ComPtr<IGameStatisticsMgr> spiMgr;
+                hr = CoCreateInstance(__uuidof(GameStatistics), nullptr, CLSCTX_ALL, IID_PPV_ARGS(spiMgr.GetAddressOf()));
                 if (SUCCEEDED(hr))
                 {
                     GAMESTATS_OPEN_TYPE ot = GAMESTATS_OPEN_OPENORCREATE;
                     GAMESTATS_OPEN_RESULT res;
-                    CComPtr<IGameStatistics> spiStats;                    
-                    hr = spiMgr->GetGameStatistics(bstrGDFPath, ot, &res, &spiStats);   
+                    ComPtr<IGameStatistics> spiStats;
+                    hr = spiMgr->GetGameStatistics(bstrGDFPath, ot, &res, spiStats.GetAddressOf());
                     if(SUCCEEDED(hr))
                     {
                         if (res == GAMESTATS_OPEN_CREATED)
@@ -193,24 +195,24 @@ int __cdecl wmain()
                             // It is a newly created statistics file
                             // In this sample we will write some example data, and display them
                             // They can then be seen in the Windows 7 Game Explorer
-                            hr = WriteStatistics(spiStats);
+                            hr = WriteStatistics(spiStats.Get());
                             if(SUCCEEDED(hr))
                             {
-                                hr = DisplayStatistics(spiStats);                       
+                                hr = DisplayStatistics(spiStats.Get());
                             }
-                            
+
                             // Uncomment this line  to remove the statistics
-                            //hr = spiMgr->RemoveGameStatistics(bstrGDFPath);     
+                            //hr = spiMgr->RemoveGameStatistics(bstrGDFPath);
                         }
                         else
                         {
-                            // If the statistics file already exists, then in this 
+                            // If the statistics file already exists, then in this
                             // sample we will just display them
-                            hr = DisplayStatistics(spiStats);                           
+                            hr = DisplayStatistics(spiStats.Get());
                         }
                     }
                 }
-                
+
                 SysFreeString(bstrGDFPath);
             }
         }

--- a/C++/Misc/PixPluginSample/PIXPluginSample.rc
+++ b/C++/Misc/PixPluginSample/PIXPluginSample.rc
@@ -7,7 +7,8 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <windows.h>
+#define IDC_STATIC -1
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For a full change history, see [CHANGELOG.md](https://github.com/microsoft/Direc
 
 * The XACT samples are not included in this repository because they will only build with the legacy DirectX SDK.
 
-* The legacy DirectSound samples from DirectX SDK (November 2007) are included for completeness. They require the optional "MFC" Visual Studio component be installed ("C++ v14.29 (16.11) MFC for v142 build tools (x86 & x64)").
+* The legacy DirectSound samples from DirectX SDK (November 2007) are included for completeness.
 
 * The Managed DX 1.1 C# samples are not included in this repository because they require both legacy .NET 1.1 and the legacy DirectX SDK to build.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,17 +14,17 @@ Instead, please report them to the Microsoft Security Response Center (MSRC) at 
 
 If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/security.md/msrc/pgp).
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 
-  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-  * Full paths of source file(s) related to the manifestation of the issue
-  * The location of the affected source code (tag/branch/commit or direct URL)
-  * Any special configuration required to reproduce the issue
-  * Step-by-step instructions to reproduce the issue
-  * Proof-of-concept or exploit code (if possible)
-  * Impact of the issue, including how an attacker might exploit the issue
+* Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+* Full paths of source file(s) related to the manifestation of the issue
+* The location of the affected source code (tag/branch/commit or direct URL)
+* Any special configuration required to reproduce the issue
+* Step-by-step instructions to reproduce the issue
+* Proof-of-concept or exploit code (if possible)
+* Impact of the issue, including how an attacker might exploit the issue
 
 This information will help us triage your report more quickly.
 


### PR DESCRIPTION
The *windows-2022* image does have v142 support, but it's missing the v142 version of Spectre-libs and more importantly, missing the v142 version of ATL/MFC. I removed the use of legacy ATL/MFC and used WRL instead where needed.
